### PR TITLE
feat(auth) : 로그인 / 회원가입 / 로그아웃 기능 추가

### DIFF
--- a/src/main/java/com/mjsec/lms/config/AdminUserInitializer.java
+++ b/src/main/java/com/mjsec/lms/config/AdminUserInitializer.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-// Admin 계정 생성을 위한 Configuration Class
+// Admin 계정 생성을 위한 Configuration Class (테스트 단계에서만 사용)
 @Configuration
 public class AdminUserInitializer {
 

--- a/src/main/java/com/mjsec/lms/config/AdminUserInitializer.java
+++ b/src/main/java/com/mjsec/lms/config/AdminUserInitializer.java
@@ -1,0 +1,40 @@
+package com.mjsec.lms.config;
+
+import com.mjsec.lms.domain.User;
+import com.mjsec.lms.repository.UserRepository;
+import com.mjsec.lms.type.UserRole;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+// Admin 계정 생성을 위한 Configuration Class
+@Configuration
+public class AdminUserInitializer {
+
+    @Value("${admin.number}")
+    private Long adminNumber;
+
+    @Value("${admin.password}")
+    private String adminPassword;
+
+    @Bean
+    public CommandLineRunner createAdminUser(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+
+        return args -> {
+            if (!userRepository.existsByStudentNumber(adminNumber)) {
+                User admin = User.builder()
+                        .studentNumber(adminNumber)
+                        .password(passwordEncoder.encode(adminPassword))
+                        .email("admin@example.com")
+                        .role(UserRole.ROLE_ADMIN)
+                        .phoneNumber("010-3727-3727")
+                        .build();
+                userRepository.save(admin);
+
+                System.out.println("관리자 계정 생성 완료: " + adminNumber);
+            }
+        };
+    }
+}

--- a/src/main/java/com/mjsec/lms/config/AdminUserInitializer.java
+++ b/src/main/java/com/mjsec/lms/config/AdminUserInitializer.java
@@ -27,9 +27,10 @@ public class AdminUserInitializer {
                 User admin = User.builder()
                         .studentNumber(adminNumber)
                         .password(passwordEncoder.encode(adminPassword))
+                        .name("관리자")
                         .email("admin@example.com")
-                        .role(UserRole.ROLE_ADMIN)
                         .phoneNumber("010-3727-3727")
+                        .role(UserRole.ROLE_ADMIN)
                         .build();
                 userRepository.save(admin);
 

--- a/src/main/java/com/mjsec/lms/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/mjsec/lms/config/PasswordEncoderConfig.java
@@ -1,0 +1,16 @@
+package com.mjsec.lms.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/mjsec/lms/config/SecurityConfig.java
+++ b/src/main/java/com/mjsec/lms/config/SecurityConfig.java
@@ -1,6 +1,9 @@
 package com.mjsec.lms.config;
 
 import com.mjsec.lms.repository.UserRepository;
+import com.mjsec.lms.security.CustomLoginFilter;
+import com.mjsec.lms.security.CustomLogoutFilter;
+import com.mjsec.lms.security.JwtFilter;
 import com.mjsec.lms.service.JwtService;
 import com.mjsec.lms.type.UserRole;
 import jakarta.servlet.http.HttpServletRequest;
@@ -64,7 +67,7 @@ public class SecurityConfig {
         http
                 .addFilterBefore(new CustomLoginFilter(userRepository, jwtService, passwordEncoder), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(new JwtFilter(jwtService), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(new CustomLogoutFilter(jwtService), LogoutFilter.class);
+                .addFilterBefore(new CustomLogoutFilter(), LogoutFilter.class);
 
         // 경로별 인가 작업
         http

--- a/src/main/java/com/mjsec/lms/config/SecurityConfig.java
+++ b/src/main/java/com/mjsec/lms/config/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/swagger-ui/*", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/users/**").permitAll() // 임시로 허용
                 );
 

--- a/src/main/java/com/mjsec/lms/config/SecurityConfig.java
+++ b/src/main/java/com/mjsec/lms/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.mjsec.lms.config;
 
 import com.mjsec.lms.repository.UserRepository;
 import com.mjsec.lms.service.JwtService;
+import com.mjsec.lms.type.UserRole;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import org.springframework.context.annotation.Bean;
@@ -70,6 +71,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/swagger-ui/*", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/v1/users/**").permitAll() // 임시로 허용
                 );
 

--- a/src/main/java/com/mjsec/lms/config/SecurityConfig.java
+++ b/src/main/java/com/mjsec/lms/config/SecurityConfig.java
@@ -1,0 +1,77 @@
+package com.mjsec.lms.config;
+
+import com.mjsec.lms.repository.UserRepository;
+import com.mjsec.lms.service.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public SecurityConfig(JwtService jwtService, UserRepository userRepository, PasswordEncoder passwordEncoder) {
+
+        this.jwtService = jwtService;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .cors(corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
+                        CorsConfiguration configuration = new CorsConfiguration();
+
+                        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000"));
+                        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+                        configuration.setAllowCredentials(true);
+                        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Set-Cookie", "X-Requested-With", "Accept"));
+                        configuration.setMaxAge(3600L);
+                        configuration.setExposedHeaders(Arrays.asList("Authorization", "access", "X-Custom-Header"));
+
+                        return configuration;
+                    }
+                }));
+
+        http
+                .csrf((auth) -> auth.disable());
+
+        http
+                .formLogin((auth) -> auth.disable());
+
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        http
+                .addFilterBefore(new CustomLoginFilter(userRepository, jwtService, passwordEncoder), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(new JwtFilter(jwtService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new CustomLogoutFilter(jwtService), LogoutFilter.class);
+
+        // 경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/swagger-ui/*", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/v1/users/**").permitAll() // 임시로 허용
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/mjsec/lms/controller/AdminController.java
+++ b/src/main/java/com/mjsec/lms/controller/AdminController.java
@@ -1,0 +1,19 @@
+package com.mjsec.lms.controller;
+
+import com.mjsec.lms.dto.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @GetMapping("/member-approval")
+    public ResponseEntity<SuccessResponse<?>>
+}

--- a/src/main/java/com/mjsec/lms/controller/AdminController.java
+++ b/src/main/java/com/mjsec/lms/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.mjsec.lms.controller;
 
 import com.mjsec.lms.dto.PendingUserDto;
 import com.mjsec.lms.dto.SuccessResponse;
+import com.mjsec.lms.service.AdminService;
 import com.mjsec.lms.type.ResponseMessage;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/mjsec/lms/controller/AdminController.java
+++ b/src/main/java/com/mjsec/lms/controller/AdminController.java
@@ -34,7 +34,7 @@ public class AdminController {
         );
     }
 
-    @PostMapping("/member-approval")
+    @PostMapping("/member-approval/{studentNumber}")
     public ResponseEntity<SuccessResponse<Void>> approveRegister(@PathVariable Long studentNumber) {
 
         adminService.approveRegister(studentNumber);

--- a/src/main/java/com/mjsec/lms/controller/AdminController.java
+++ b/src/main/java/com/mjsec/lms/controller/AdminController.java
@@ -1,9 +1,15 @@
 package com.mjsec.lms.controller;
 
+import com.mjsec.lms.dto.PendingUserDto;
 import com.mjsec.lms.dto.SuccessResponse;
+import com.mjsec.lms.type.ResponseMessage;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,5 +21,27 @@ public class AdminController {
     private final AdminService adminService;
 
     @GetMapping("/member-approval")
-    public ResponseEntity<SuccessResponse<?>>
+    public ResponseEntity<SuccessResponse<List<PendingUserDto>>> getAllPendingUser(){
+
+        List<PendingUserDto> pendingUsers = adminService.getAllPendingUser();
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.GET_ALL_PENDING_USER_SUCCESS,
+                        pendingUsers
+                )
+        );
+    }
+
+    @PostMapping("/member-approval")
+    public ResponseEntity<SuccessResponse<Void>> approveRegister(@PathVariable Long studentNumber) {
+
+        adminService.approveRegister(studentNumber);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.APPROVE_REGISTER_SUCCESS
+                )
+        );
+    }
 }

--- a/src/main/java/com/mjsec/lms/controller/AuthController.java
+++ b/src/main/java/com/mjsec/lms/controller/AuthController.java
@@ -1,0 +1,43 @@
+package com.mjsec.lms.controller;
+
+import com.mjsec.lms.dto.SuccessResponse;
+import com.mjsec.lms.service.AuthService;
+import com.mjsec.lms.type.ResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/check-student-number")
+    public ResponseEntity<SuccessResponse<Boolean>> checkStudentNumber(
+            @RequestParam Long studentNumber
+    ) {
+
+        if(authService.checkStudentNumber(studentNumber)){
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    SuccessResponse.of(
+                            ResponseMessage.STUDENT_NUMBER_CHECK_SUCCESS,
+                            true
+                    )
+            );
+        }
+        else {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                    SuccessResponse.of(
+                            ResponseMessage.DUPLICATE_STUDENT_NUMBER,
+                            false
+                    )
+            );
+        }
+    }
+}

--- a/src/main/java/com/mjsec/lms/controller/AuthController.java
+++ b/src/main/java/com/mjsec/lms/controller/AuthController.java
@@ -40,4 +40,25 @@ public class AuthController {
             );
         }
     }
+
+    @GetMapping("/check-email")
+    public ResponseEntity<SuccessResponse<Boolean>> checkEmail(@RequestParam String email){
+
+        if(authService.checkEmail(email)) {
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    SuccessResponse.of(
+                            ResponseMessage.EMAIL_CHECL_SUCCESS,
+                            true
+                    )
+            );
+        }
+        else {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                    SuccessResponse.of(
+                            ResponseMessage.DUPLICATE_EMAIL,
+                            false
+                    )
+            );
+        }
+    }
 }

--- a/src/main/java/com/mjsec/lms/controller/AuthController.java
+++ b/src/main/java/com/mjsec/lms/controller/AuthController.java
@@ -1,12 +1,16 @@
 package com.mjsec.lms.controller;
 
+import com.mjsec.lms.dto.AuthDto;
 import com.mjsec.lms.dto.SuccessResponse;
 import com.mjsec.lms.service.AuthService;
 import com.mjsec.lms.type.ResponseMessage;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -60,5 +64,19 @@ public class AuthController {
                     )
             );
         }
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<SuccessResponse<Void>> register(
+            @RequestBody @Valid AuthDto.Register registerRequest
+    ){
+
+        authService.register(registerRequest);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.REGISTER_SUCCESS
+                )
+        );
     }
 }

--- a/src/main/java/com/mjsec/lms/domain/BaseEntity.java
+++ b/src/main/java/com/mjsec/lms/domain/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.mjsec.lms.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@MappedSuperclass
+@SuperBuilder(builderMethodName = "doesNotUseThisBuilder")
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/mjsec/lms/domain/PendingUser.java
+++ b/src/main/java/com/mjsec/lms/domain/PendingUser.java
@@ -1,0 +1,40 @@
+package com.mjsec.lms.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PendingUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long pendingUserId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false, unique = true)
+    private Long studentNumber;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+}

--- a/src/main/java/com/mjsec/lms/domain/PendingUser.java
+++ b/src/main/java/com/mjsec/lms/domain/PendingUser.java
@@ -23,6 +23,9 @@ public class PendingUser {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long pendingUserId;
 
+    @Column(nullable = false, unique = true)
+    private Long studentNumber;
+
     @Column(nullable = false)
     private String password;
 
@@ -31,9 +34,6 @@ public class PendingUser {
 
     @Column(nullable = false, unique = true)
     private String email;
-
-    @Column(nullable = false, unique = true)
-    private Long studentNumber;
 
     @Column(nullable = false)
     private String phoneNumber;

--- a/src/main/java/com/mjsec/lms/domain/User.java
+++ b/src/main/java/com/mjsec/lms/domain/User.java
@@ -1,0 +1,57 @@
+package com.mjsec.lms.domain;
+
+import com.mjsec.lms.type.UserRole;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Inheritance(strategy = InheritanceType.JOINED)
+@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE user_id = ?")
+@SQLRestriction("deleted_at is null")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false, unique = true)
+    private Long studentNumber;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(length = 512)
+    private String profileImage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+}

--- a/src/main/java/com/mjsec/lms/dto/AuthDto.java
+++ b/src/main/java/com/mjsec/lms/dto/AuthDto.java
@@ -1,0 +1,21 @@
+package com.mjsec.lms.dto;
+
+import jakarta.validation.Valid;
+import lombok.Data;
+
+public class AuthDto {
+
+    @Data
+    public static class LogIn {
+
+        private String loginId;
+        private String password;
+    }
+
+    @Data
+    public static class Register {
+
+        @Valid
+        private UserDto userDto;
+    }
+}

--- a/src/main/java/com/mjsec/lms/dto/AuthDto.java
+++ b/src/main/java/com/mjsec/lms/dto/AuthDto.java
@@ -1,6 +1,10 @@
 package com.mjsec.lms.dto;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 public class AuthDto {
@@ -8,7 +12,15 @@ public class AuthDto {
     @Data
     public static class LogIn {
 
-        private String loginId;
+        @NotNull(message = "학번은 필수입니다.")
+        @Min(value = 10000000, message = "학번은 8자리여야 합니다.")
+        @Max(value = 99999999, message = "학번은 8자리여야 합니다.")
+        private Long studentNumber;
+
+        @Pattern(
+                regexp = "^(?=(?:.*[a-z]))(?=(?:.*[A-Z]))(?=(?:.*\\\\d){5,})(?=(?:.*[\\\\W_]){2,}).{8,}$\n",
+                message = "비밀번호는 총 8자 이상이며 대소문자, 숫자 5개 이상, 특수문자 2개 이상을 포함해야 합니다."
+        )
         private String password;
     }
 

--- a/src/main/java/com/mjsec/lms/dto/ErrorResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/ErrorResponse.java
@@ -1,0 +1,28 @@
+package com.mjsec.lms.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Builder;
+import org.springframework.validation.FieldError;
+
+@Builder
+public record ErrorResponse(
+        String code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY) List<ValidationError> errors
+) {
+
+    @Builder
+    public record ValidationError(
+            String field,
+            String message
+    ) {
+        public static ValidationError of(final FieldError fieldError){
+
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/mjsec/lms/dto/PendingUserDto.java
+++ b/src/main/java/com/mjsec/lms/dto/PendingUserDto.java
@@ -1,8 +1,10 @@
 package com.mjsec.lms.dto;
 
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class PendingUserDto {
 
     private Long studentNumber;

--- a/src/main/java/com/mjsec/lms/dto/PendingUserDto.java
+++ b/src/main/java/com/mjsec/lms/dto/PendingUserDto.java
@@ -1,0 +1,15 @@
+package com.mjsec.lms.dto;
+
+import lombok.Data;
+
+@Data
+public class PendingUserDto {
+
+    private Long studentNumber;
+
+    private String name;
+
+    private String email;
+
+    private String phoneNumber;
+}

--- a/src/main/java/com/mjsec/lms/dto/SuccessResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/SuccessResponse.java
@@ -1,0 +1,39 @@
+package com.mjsec.lms.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.mjsec.lms.type.ResponseMessage;
+import lombok.Builder;
+
+@Builder
+public record SuccessResponse<T>(
+        String code,
+        String message,
+        @JsonInclude(Include.NON_NULL) T data
+) {
+    public static <T> SuccessResponse<T> of(ResponseMessage message, T data) {
+
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message(message.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static <T> SuccessResponse<T> of(ResponseMessage message) {
+
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message(message.getMessage())
+                .build();
+    }
+
+    public static <T> SuccessResponse<T> of(T data) {
+
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message("")
+                .data(data)
+                .build();
+    }
+}

--- a/src/main/java/com/mjsec/lms/dto/UserDto.java
+++ b/src/main/java/com/mjsec/lms/dto/UserDto.java
@@ -2,7 +2,10 @@ package com.mjsec.lms.dto;
 
 import com.mjsec.lms.domain.User;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,8 +20,10 @@ import lombok.Setter;
 @AllArgsConstructor
 public class UserDto {
 
-    @NotBlank
-    private String loginId;
+    @NotNull(message = "학번은 필수입니다.")
+    @Min(value = 10000000, message = "학번은 8자리여야 합니다.")
+    @Max(value = 99999999, message = "학번은 8자리여야 합니다.")
+    private Long studentNumber;
 
     @Pattern(
             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d{5,})(?=.*[\\W_]{2,}).*$",
@@ -35,19 +40,7 @@ public class UserDto {
     @NotBlank
     private String email;
 
-    @Pattern(regexp = "^\\d{8}$", message = "학번은 8자리 숫자여야 합니다.")
-    @NotBlank
-    private String studentId;
-
     @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호는 010-xxxx-xxxx 형식이어야 합니다.")
     @NotBlank
-    private String phone;
-
-    public static UserDto from(User user) {
-
-        return UserDto.builder()
-                .name(user.getName())
-                .email(user.getEmail())
-                .build();
-    }
+    private String phoneNumber;
 }

--- a/src/main/java/com/mjsec/lms/dto/UserDto.java
+++ b/src/main/java/com/mjsec/lms/dto/UserDto.java
@@ -26,8 +26,8 @@ public class UserDto {
     private Long studentNumber;
 
     @Pattern(
-            regexp = "^(?=(?:.*[a-z]))(?=(?:.*[A-Z]))(?=(?:.*\\\\d){5,})(?=(?:.*[\\\\W_]){2,}).{8,}$\n",
-            message = "비밀번호는 총 8자 이상이며 대소문자, 숫자 5개 이상, 특수문자 2개 이상을 포함해야 합니다."
+            regexp = "^(?=.*[A-Z])(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*()-+=]).{8,}$",
+            message = "비밀번호는 대소문자, 숫자, 특수문자를 포함해야 합니다."
     )
     @NotBlank
     private String password;

--- a/src/main/java/com/mjsec/lms/dto/UserDto.java
+++ b/src/main/java/com/mjsec/lms/dto/UserDto.java
@@ -26,13 +26,13 @@ public class UserDto {
     private Long studentNumber;
 
     @Pattern(
-            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d{5,})(?=.*[\\W_]{2,}).*$",
-            message = "비밀번호는 대소문자, 숫자 5개 이상, 특수문자 2개 이상을 포함해야 합니다."
+            regexp = "^(?=(?:.*[a-z]))(?=(?:.*[A-Z]))(?=(?:.*\\\\d){5,})(?=(?:.*[\\\\W_]){2,}).{8,}$\n",
+            message = "비밀번호는 총 8자 이상이며 대소문자, 숫자 5개 이상, 특수문자 2개 이상을 포함해야 합니다."
     )
     @NotBlank
     private String password;
 
-    @Pattern(regexp = "^[ㄱ-ㅎ|가-힣]*$", message = "사용자 이름은 한글로만 이루어져야 합니다.")
+    @Pattern(regexp = "^[가-힣]+$", message = "사용자 이름은 한글로만 이루어져야 합니다.")
     @NotBlank
     private String name;
 

--- a/src/main/java/com/mjsec/lms/dto/UserDto.java
+++ b/src/main/java/com/mjsec/lms/dto/UserDto.java
@@ -1,0 +1,53 @@
+package com.mjsec.lms.dto;
+
+import com.mjsec.lms.domain.User;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDto {
+
+    @NotBlank
+    private String loginId;
+
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d{5,})(?=.*[\\W_]{2,}).*$",
+            message = "비밀번호는 대소문자, 숫자 5개 이상, 특수문자 2개 이상을 포함해야 합니다."
+    )
+    @NotBlank
+    private String password;
+
+    @Pattern(regexp = "^[ㄱ-ㅎ|가-힣]*$", message = "사용자 이름은 한글로만 이루어져야 합니다.")
+    @NotBlank
+    private String name;
+
+    @Email(message = "유효한 이메일 주소 형식이어야 합니다.")
+    @NotBlank
+    private String email;
+
+    @Pattern(regexp = "^\\d{8}$", message = "학번은 8자리 숫자여야 합니다.")
+    @NotBlank
+    private String studentId;
+
+    @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호는 010-xxxx-xxxx 형식이어야 합니다.")
+    @NotBlank
+    private String phone;
+
+    public static UserDto from(User user) {
+
+        return UserDto.builder()
+                .name(user.getName())
+                .email(user.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/mjsec/lms/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mjsec/lms/exception/GlobalExceptionHandler.java
@@ -1,0 +1,142 @@
+package com.mjsec.lms.exception;
+
+import static com.mjsec.lms.type.ErrorCode.BAD_REQUEST;
+import static com.mjsec.lms.type.ErrorCode.INTERNAL_SERVER_ERROR;
+
+import com.mjsec.lms.dto.ErrorResponse;
+import com.mjsec.lms.dto.ErrorResponse.ValidationError;
+import com.mjsec.lms.type.ErrorCode;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     * RestApiException(커스텀 에러) 처리
+     *
+     * @param e RestApiException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(RestApiException.class)
+    public ResponseEntity<Object> handleCustomException(RestApiException e){
+
+        ErrorCode errorCode = e.getErrorCode();
+        log.error("RestApiException occurred : ErrorCode = {} message = {}",
+                errorCode.name(), errorCode.getDescription());
+        return handleExceptionInternal(errorCode);
+    }
+//
+    /**
+     * MethodArgumentNotValidException 처리 (Validation 실패 등)
+     *
+     * @param e MethodArgumentNotValidException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+
+        log.error("Validation failed", e);
+        return handleValidationException(e, BAD_REQUEST);
+    }
+
+    private ResponseEntity<Object> handleValidationException(MethodArgumentNotValidException e, ErrorCode errorCode) {
+
+        List<ValidationError> validationErrors = e.getBindingResult().getFieldErrors()
+                .stream()
+                .map(ValidationError::of)
+                .collect(Collectors.toList());
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getDescription())
+                .errors(validationErrors)
+                .build();
+
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+    }
+
+    /**
+     * IllegalArgumentException 처리 (적절하지 않은 파라미터)
+     *
+     * @param e IllegalArgumentException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
+
+        log.error("IllegalArgumentException occurred", e);
+        return handleExceptionInternal(BAD_REQUEST);
+    }
+
+    /**
+     * DataIntegrityViolationException 처리 (DB 제약 조건 위반)
+     *
+     * @param e DataIntegrityViolationException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Object> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+
+        log.error("DataIntegrityViolationException occurred", e);
+        return handleExceptionInternal(BAD_REQUEST);
+    }
+
+    /**
+     * Exception 처리
+     *
+     * @param e Exception
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleException(Exception e) {
+
+        log.error("Unexpected Exception occurred", e);
+        return ResponseEntity
+                .status(INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(INTERNAL_SERVER_ERROR.getDescription());
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponseBody(errorCode));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorCode errorCode) {
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponseBody((MethodArgumentNotValidException) e, errorCode));
+    }
+
+    private ErrorResponse makeErrorResponseBody(ErrorCode errorCode) {
+
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getDescription())
+                .build();
+    }
+
+    private ErrorResponse makeErrorResponseBody(BindException e, ErrorCode errorCode) {
+
+        List<ValidationError> validationErrorList = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ValidationError::of)
+                .collect(Collectors.toList());
+
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getDescription())
+                .errors(validationErrorList)
+                .build();
+    }
+}

--- a/src/main/java/com/mjsec/lms/exception/RestApiException.java
+++ b/src/main/java/com/mjsec/lms/exception/RestApiException.java
@@ -1,0 +1,20 @@
+package com.mjsec.lms.exception;
+
+import com.mjsec.lms.type.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RestApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public RestApiException(ErrorCode errorCode) {
+
+        super(errorCode.getDescription());
+        this.errorCode = errorCode;
+        this.message = errorCode.getDescription();
+    }
+}

--- a/src/main/java/com/mjsec/lms/repository/PendingUserRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/PendingUserRepository.java
@@ -1,0 +1,11 @@
+package com.mjsec.lms.repository;
+
+import com.mjsec.lms.domain.PendingUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PendingUserRepository extends JpaRepository<PendingUser, Long> {
+
+    boolean existsByStudentNumber(Long studentNumber);
+}

--- a/src/main/java/com/mjsec/lms/repository/PendingUserRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/PendingUserRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface PendingUserRepository extends JpaRepository<PendingUser, Long> {
 
     boolean existsByStudentNumber(Long studentNumber);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/mjsec/lms/repository/PendingUserRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/PendingUserRepository.java
@@ -1,6 +1,8 @@
 package com.mjsec.lms.repository;
 
 import com.mjsec.lms.domain.PendingUser;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +12,6 @@ public interface PendingUserRepository extends JpaRepository<PendingUser, Long> 
     boolean existsByStudentNumber(Long studentNumber);
 
     boolean existsByEmail(String email);
+
+    Optional<PendingUser> findByStudentNumber(Long studentNumber);
 }

--- a/src/main/java/com/mjsec/lms/repository/UserRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.mjsec.lms.repository;
 
 import com.mjsec.lms.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByStudentNumber(Long studentNumber);
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByStudentNumber(Long studentNumber);
 }

--- a/src/main/java/com/mjsec/lms/repository/UserRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.mjsec.lms.repository;
+
+import com.mjsec.lms.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByStudentNumber(Long studentNumber);
+}

--- a/src/main/java/com/mjsec/lms/repository/UserRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/UserRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByStudentNumber(Long studentNumber);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/mjsec/lms/security/CustomLoginFilter.java
+++ b/src/main/java/com/mjsec/lms/security/CustomLoginFilter.java
@@ -1,0 +1,122 @@
+package com.mjsec.lms.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mjsec.lms.domain.User;
+import com.mjsec.lms.dto.AuthDto;
+import com.mjsec.lms.repository.UserRepository;
+import com.mjsec.lms.service.JwtService;
+import com.mjsec.lms.type.ErrorCode;
+import com.mjsec.lms.type.UserRole;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.filter.GenericFilterBean;
+
+@Slf4j
+public class CustomLoginFilter extends GenericFilterBean {
+
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
+    private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 변환용
+
+    public CustomLoginFilter(UserRepository userRepository, JwtService jwtService, PasswordEncoder passwordEncoder) {
+
+        this.userRepository = userRepository;
+        this.jwtService = jwtService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, filterChain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        // 로그인 요청(POST)이 아닐 경우, 다음 필터로 넘김
+        if (!request.getServletPath().equalsIgnoreCase("/api/v1/auth/login") ||
+                !"POST".equalsIgnoreCase(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 요청 본문에서 JSON 데이터 추출
+        AuthDto.LogIn loginRequest;
+        try {
+            loginRequest = objectMapper.readValue(request.getInputStream(), AuthDto.LogIn.class);
+        } catch (IOException e) {
+            log.error("Invalid login request format: {}", e.getMessage());
+            sendErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST, ErrorCode.INVALID_REQUEST_FORMAT);
+            return;
+        }
+
+        // 학번 검증 (학번이 존재하지 않는 경우)
+        User user = userRepository.findByStudentNumber(loginRequest.getStudentNumber()).orElse(null);
+        if (user == null) {
+            log.warn("Invalid login attempt: nonexistent student number {}", loginRequest.getStudentNumber());
+            sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, ErrorCode.INVALID_STUDENT_NUMBER);
+            return;
+        }
+
+        // 비밀번호 검증 (비밀번호가 틀린 경우)
+        if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
+            log.warn("Invalid login attempt: wrong password for student number {}", loginRequest.getStudentNumber());
+            sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, ErrorCode.INVALID_PASSWORD);
+            return;
+        }
+
+        // AccessToken 발급
+        final long ACCESS_TOKEN_EXPIRY = 43_200_000L; // 12시간
+
+        // User 권한 정보 획득
+        UserRole role = user.getRole();
+
+        // AccessToken 생성
+        String accessToken = jwtService.createJwt(
+                "accessToken",
+                user.getStudentNumber(),
+                String.valueOf(role),
+                ACCESS_TOKEN_EXPIRY
+        );
+
+        // AccessToken 헤더에 추가
+        response.setHeader("Authorization", "Bearer " + accessToken);
+
+        // 성공 응답 (테스트 단계에서만 사용)
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("message", "로그인 성공!");
+        message.put("accessToken", accessToken);
+
+        objectMapper.writeValue(response.getWriter(), message);
+
+        log.info("User '{}' logged in successfully", user.getStudentNumber());
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, int status, ErrorCode errorCode) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("code", errorCode.name());
+        errorResponse.put("message", errorCode.getDescription());
+
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/src/main/java/com/mjsec/lms/security/CustomLogoutFilter.java
+++ b/src/main/java/com/mjsec/lms/security/CustomLogoutFilter.java
@@ -1,0 +1,53 @@
+package com.mjsec.lms.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.GenericFilterBean;
+
+@Slf4j
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, filterChain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        // 로그아웃 요청이 아닌 경우 다음 필터로 진행
+        if (!request.getRequestURI().equals("/api/v1/auth/logout") || !"POST".equalsIgnoreCase(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Authorization 헤더 검증
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "{\"error\": \"Missing or invalid Authorization header\"}");
+            return;
+        }
+
+        // 현재는 Refresh Token 을 사용하지 않기 때문에 별도의 토큰 블랙리스트화 작업 X
+
+        // 로그아웃 성공 응답
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> responseMessage = new HashMap<>();
+        responseMessage.put("message", "로그아웃 성공");
+
+        objectMapper.writeValue(response.getWriter(), responseMessage);
+    }
+}
+

--- a/src/main/java/com/mjsec/lms/security/JwtFilter.java
+++ b/src/main/java/com/mjsec/lms/security/JwtFilter.java
@@ -1,0 +1,88 @@
+package com.mjsec.lms.security;
+
+import com.mjsec.lms.service.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    private static final List<String> PUBLIC_ENDPOINTS = List.of(
+            "/api/v1/auth/**"
+    );
+
+    public JwtFilter(JwtService jwtService) {
+
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String requestURI = request.getRequestURI();
+        log.info("Starting JWTFilter for request: {}", requestURI);
+
+        // Public Endpoint 인지 확인
+        boolean isPublic = PUBLIC_ENDPOINTS.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, requestURI));
+
+        if (isPublic) {
+            log.info("Skipping JWT filter for public endpoint: {}", requestURI);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            log.warn("Authorization header missing or malformed");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Authorization header missing or malformed");
+            return;
+        }
+
+        String accessToken = authorizationHeader.substring(7);
+
+        if (jwtService.isExpired(accessToken)) {
+            log.warn("Access token expired");
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Access token expired");
+            return;
+        }
+
+        String tokenType = jwtService.getTokenType(accessToken);
+        if (!"accessToken".equals(tokenType)) {
+            log.warn("Invalid token type: {}", tokenType);
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid access token");
+            return;
+        }
+
+        Long studentNumber = jwtService.getStudentNumber(accessToken);
+        String role = jwtService.getRole(accessToken);
+
+        log.info("Authenticated user: {}, Role: {}", studentNumber, role);
+
+        List<SimpleGrantedAuthority> authorities =
+                Collections.singletonList(new SimpleGrantedAuthority(role));
+
+        Authentication authToken = new UsernamePasswordAuthenticationToken(studentNumber, null, authorities);
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+        log.info("Completed JWTFilter for request: {}", requestURI);
+    }
+}

--- a/src/main/java/com/mjsec/lms/service/AdminService.java
+++ b/src/main/java/com/mjsec/lms/service/AdminService.java
@@ -10,7 +10,6 @@ import com.mjsec.lms.type.ErrorCode;
 import com.mjsec.lms.type.UserRole;
 import jakarta.transaction.Transactional;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/mjsec/lms/service/AdminService.java
+++ b/src/main/java/com/mjsec/lms/service/AdminService.java
@@ -33,6 +33,8 @@ public class AdminService {
      */
     public List<PendingUserDto> getAllPendingUser() {
 
+        log.info("Getting all pending users");
+
         List<PendingUser> allPendingUsers = pendingUserRepository.findAll();
 
         return allPendingUsers.stream()
@@ -52,11 +54,14 @@ public class AdminService {
     @Transactional
     public void approveRegister(Long studentNumber){
 
+        log.info("Approve registration for {}", studentNumber);
+
         PendingUser pendingUser = pendingUserRepository.findByStudentNumber(studentNumber)
                 .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
 
         if (userRepository.existsByStudentNumber(pendingUser.getStudentNumber()) ||
                 userRepository.existsByEmail(pendingUser.getEmail())) {
+            log.warn("Already existing user: {}", studentNumber);
             throw new RestApiException(ErrorCode.ALREADY_REGISTERED_USER);
         }
 
@@ -71,5 +76,6 @@ public class AdminService {
 
         userRepository.save(user);
         pendingUserRepository.delete(pendingUser);
+        log.info("Moved pending user to approved user: {}", user.getStudentNumber());
     }
 }

--- a/src/main/java/com/mjsec/lms/service/AdminService.java
+++ b/src/main/java/com/mjsec/lms/service/AdminService.java
@@ -1,0 +1,76 @@
+package com.mjsec.lms.service;
+
+import com.mjsec.lms.domain.PendingUser;
+import com.mjsec.lms.domain.User;
+import com.mjsec.lms.dto.PendingUserDto;
+import com.mjsec.lms.exception.RestApiException;
+import com.mjsec.lms.repository.PendingUserRepository;
+import com.mjsec.lms.repository.UserRepository;
+import com.mjsec.lms.type.ErrorCode;
+import com.mjsec.lms.type.UserRole;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class AdminService {
+
+    private final PendingUserRepository pendingUserRepository;
+    private final UserRepository userRepository;
+
+
+    public AdminService(PendingUserRepository pendingUserRepository, UserRepository userRepository) {
+
+        this.pendingUserRepository = pendingUserRepository;
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 회원가입 승인 대기자 목록을 반환하는 메소드
+     * @return List<PendingUserDto> (각 PendingUserDto는 학번, 이름, 이메일, 전화번호 정보를 담음)
+     */
+    public List<PendingUserDto> getAllPendingUser() {
+
+        List<PendingUser> allPendingUsers = pendingUserRepository.findAll();
+
+        return allPendingUsers.stream()
+                .map(user -> PendingUserDto.builder()
+                        .studentNumber(user.getStudentNumber())
+                        .name(user.getName())
+                        .email(user.getEmail())
+                        .phoneNumber(user.getPhoneNumber())
+                        .build())
+                .toList();
+    }
+
+    /**
+     * 회원가입 승인을 위한 메소드
+     * @param studentNumber 학번
+     */
+    @Transactional
+    public void approveRegister(Long studentNumber){
+
+        PendingUser pendingUser = pendingUserRepository.findByStudentNumber(studentNumber)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+        if (userRepository.existsByStudentNumber(pendingUser.getStudentNumber()) ||
+                userRepository.existsByEmail(pendingUser.getEmail())) {
+            throw new RestApiException(ErrorCode.ALREADY_REGISTERED_USER);
+        }
+
+        User user = User.builder()
+                .studentNumber(pendingUser.getStudentNumber())
+                .password(pendingUser.getPassword())
+                .name(pendingUser.getName())
+                .email(pendingUser.getEmail())
+                .phoneNumber(pendingUser.getPhoneNumber())
+                .role(UserRole.ROLE_USER)
+                .build();
+
+        userRepository.save(user);
+        pendingUserRepository.delete(pendingUser);
+    }
+}

--- a/src/main/java/com/mjsec/lms/service/AuthService.java
+++ b/src/main/java/com/mjsec/lms/service/AuthService.java
@@ -1,10 +1,14 @@
 package com.mjsec.lms.service;
 
+import com.mjsec.lms.domain.PendingUser;
+import com.mjsec.lms.dto.AuthDto;
+import com.mjsec.lms.dto.UserDto;
 import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.repository.PendingUserRepository;
 import com.mjsec.lms.repository.UserRepository;
 import com.mjsec.lms.type.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -13,11 +17,14 @@ public class AuthService {
 
     private final PendingUserRepository pendingUserRepository;
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public AuthService(PendingUserRepository pendingUserRepository, UserRepository userRepository) {
+    public AuthService(PendingUserRepository pendingUserRepository, UserRepository userRepository,
+                       PasswordEncoder passwordEncoder) {
 
         this.pendingUserRepository = pendingUserRepository;
         this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     /**
@@ -56,5 +63,41 @@ public class AuthService {
         if(userRepository.existsByEmail(email)) return false;
 
         return true;
+    }
+
+
+    /**
+     * 회원가입 승인 요청을 처리하는 메소드
+     * @param registerRequest 유저의 개인 정보를 담은 Dto
+     */
+    public void register(AuthDto.Register registerRequest){
+
+        UserDto userDto = registerRequest.getUserDto();
+
+        // 학번 중복 체크
+        if(pendingUserRepository.existsByStudentNumber(userDto.getStudentNumber())){
+            throw new RestApiException(ErrorCode.DUPLICATE_STUDENT_NUMBER);
+        }
+        if(userRepository.existsByStudentNumber(userDto.getStudentNumber())){
+            throw new RestApiException(ErrorCode.DUPLICATE_STUDENT_NUMBER);
+        }
+
+        // 이메일 중복 체크
+        if(pendingUserRepository.existsByEmail(userDto.getEmail())){
+            throw new RestApiException(ErrorCode.DUPLICATE_EMAIL);
+        }
+        if(userRepository.existsByEmail(userDto.getEmail())){
+            throw new RestApiException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        PendingUser pendingUser = PendingUser.builder()
+                .studentNumber(userDto.getStudentNumber())
+                .password(passwordEncoder.encode(userDto.getPassword()))
+                .name(userDto.getName())
+                .email(userDto.getEmail())
+                .phoneNumber(userDto.getPhoneNumber())
+                .build();
+
+        pendingUserRepository.save(pendingUser);
     }
 }

--- a/src/main/java/com/mjsec/lms/service/AuthService.java
+++ b/src/main/java/com/mjsec/lms/service/AuthService.java
@@ -1,0 +1,33 @@
+package com.mjsec.lms.service;
+
+import com.mjsec.lms.repository.PendingUserRepository;
+import com.mjsec.lms.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class AuthService {
+
+    private final PendingUserRepository pendingUserRepository;
+    private final UserRepository userRepository;
+
+    public AuthService(PendingUserRepository pendingUserRepository, UserRepository userRepository) {
+
+        this.pendingUserRepository = pendingUserRepository;
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 사용 중인 학번인지 체크하는 메소드 (회원가입 승인 대기 중인 테이블까지 확인)
+     * @param studentNumber 학번
+     * @return true / false
+     */
+    public Boolean checkStudentNumber(Long studentNumber){
+
+        if(pendingUserRepository.existsByStudentNumber(studentNumber)) return false;
+        if(userRepository.existsByStudentNumber(studentNumber)) return false;
+
+        return true;
+    }
+}

--- a/src/main/java/com/mjsec/lms/service/AuthService.java
+++ b/src/main/java/com/mjsec/lms/service/AuthService.java
@@ -1,7 +1,9 @@
 package com.mjsec.lms.service;
 
+import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.repository.PendingUserRepository;
 import com.mjsec.lms.repository.UserRepository;
+import com.mjsec.lms.type.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -25,6 +27,12 @@ public class AuthService {
      */
     public Boolean checkStudentNumber(Long studentNumber){
 
+        // 학번이 8자리 숫자인지 체크
+        if(!String.valueOf(studentNumber).matches("^\\d{8}$")){
+            throw new RestApiException(ErrorCode.INVALID_STUDENT_NUMBER);
+        }
+
+        // 학번이 회원가입 승인 대기 중인 테이블 & 유저 테이블에 등록되어 있는지 확인
         if(pendingUserRepository.existsByStudentNumber(studentNumber)) return false;
         if(userRepository.existsByStudentNumber(studentNumber)) return false;
 

--- a/src/main/java/com/mjsec/lms/service/AuthService.java
+++ b/src/main/java/com/mjsec/lms/service/AuthService.java
@@ -90,6 +90,7 @@ public class AuthService {
             throw new RestApiException(ErrorCode.DUPLICATE_EMAIL);
         }
 
+        // 회원의 정보를 User 테이블이 아닌 승인 요청을 저장하는 PendingUser 테이블에 (임시) 저장
         PendingUser pendingUser = PendingUser.builder()
                 .studentNumber(userDto.getStudentNumber())
                 .password(passwordEncoder.encode(userDto.getPassword()))

--- a/src/main/java/com/mjsec/lms/service/AuthService.java
+++ b/src/main/java/com/mjsec/lms/service/AuthService.java
@@ -28,13 +28,32 @@ public class AuthService {
     public Boolean checkStudentNumber(Long studentNumber){
 
         // 학번이 8자리 숫자인지 체크
-        if(!String.valueOf(studentNumber).matches("^\\d{8}$")){
+        if(studentNumber == null || !String.valueOf(studentNumber).matches("^\\d{8}$")){
             throw new RestApiException(ErrorCode.INVALID_STUDENT_NUMBER);
         }
 
         // 학번이 회원가입 승인 대기 중인 테이블 & 유저 테이블에 등록되어 있는지 확인
         if(pendingUserRepository.existsByStudentNumber(studentNumber)) return false;
         if(userRepository.existsByStudentNumber(studentNumber)) return false;
+
+        return true;
+    }
+
+    /**
+     * 사용 중인 이메일인지 체크하는 메소드 (회원가입 승인 대기 중인 테이블까지 확인)
+     * @param email 이메일
+     * @return true / false
+     */
+    public Boolean checkEmail(String email){
+
+        // 이메일 형식에 맞는지 체크
+        if(email == null || !email.matches("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")){
+            throw new RestApiException(ErrorCode.INVALID_EMAIL_FORMAT);
+        }
+
+        // 이메일이 회원가입 승인 대기 중인 테이블 & 유저 테이블에 등록되어 있는지 확인
+        if(pendingUserRepository.existsByEmail(email)) return false;
+        if(userRepository.existsByEmail(email)) return false;
 
         return true;
     }

--- a/src/main/java/com/mjsec/lms/service/AuthService.java
+++ b/src/main/java/com/mjsec/lms/service/AuthService.java
@@ -36,13 +36,21 @@ public class AuthService {
 
         // 학번이 8자리 숫자인지 체크
         if(studentNumber == null || !String.valueOf(studentNumber).matches("^\\d{8}$")){
+            log.warn("Invalid student number format: {}", studentNumber);
             throw new RestApiException(ErrorCode.INVALID_STUDENT_NUMBER);
         }
 
         // 학번이 회원가입 승인 대기 중인 테이블 & 유저 테이블에 등록되어 있는지 확인
-        if(pendingUserRepository.existsByStudentNumber(studentNumber)) return false;
-        if(userRepository.existsByStudentNumber(studentNumber)) return false;
+        if(pendingUserRepository.existsByStudentNumber(studentNumber)) {
+            log.info("Student number {} already exists in PendingUser", studentNumber);
+            return false;
+        }
+        if(userRepository.existsByStudentNumber(studentNumber)) {
+            log.info("Student number {} already exists in User", studentNumber);
+            return false;
+        }
 
+        log.info("Student number {} is available", studentNumber);
         return true;
     }
 
@@ -53,15 +61,25 @@ public class AuthService {
      */
     public Boolean checkEmail(String email){
 
+        log.info("checkEmail called with email: {}", email);
+
         // 이메일 형식에 맞는지 체크
         if(email == null || !email.matches("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")){
+            log.warn("Invalid email format: {}", email);
             throw new RestApiException(ErrorCode.INVALID_EMAIL_FORMAT);
         }
 
         // 이메일이 회원가입 승인 대기 중인 테이블 & 유저 테이블에 등록되어 있는지 확인
-        if(pendingUserRepository.existsByEmail(email)) return false;
-        if(userRepository.existsByEmail(email)) return false;
+        if(pendingUserRepository.existsByEmail(email)) {
+            log.info("Email {} already exists in PendingUser", email);
+            return false;
+        }
+        if(userRepository.existsByEmail(email)) {
+            log.info("Email {} already exists in User", email);
+            return false;
+        }
 
+        log.info("Email {} is available", email);
         return true;
     }
 
@@ -72,21 +90,27 @@ public class AuthService {
      */
     public void register(AuthDto.Register registerRequest){
 
+        log.info("register called with studentNumber: {}", registerRequest.getUserDto().getStudentNumber());
+
         UserDto userDto = registerRequest.getUserDto();
 
         // 학번 중복 체크
         if(pendingUserRepository.existsByStudentNumber(userDto.getStudentNumber())){
+            log.warn("Duplicate student number in PendingUser: {}", userDto.getStudentNumber());
             throw new RestApiException(ErrorCode.DUPLICATE_STUDENT_NUMBER);
         }
         if(userRepository.existsByStudentNumber(userDto.getStudentNumber())){
+            log.warn("Duplicate student number in User: {}", userDto.getStudentNumber());
             throw new RestApiException(ErrorCode.DUPLICATE_STUDENT_NUMBER);
         }
 
         // 이메일 중복 체크
         if(pendingUserRepository.existsByEmail(userDto.getEmail())){
+            log.warn("Duplicate email in PendingUser: {}", userDto.getEmail());
             throw new RestApiException(ErrorCode.DUPLICATE_EMAIL);
         }
         if(userRepository.existsByEmail(userDto.getEmail())){
+            log.warn("Duplicate email in User: {}", userDto.getEmail());
             throw new RestApiException(ErrorCode.DUPLICATE_EMAIL);
         }
 
@@ -100,5 +124,7 @@ public class AuthService {
                 .build();
 
         pendingUserRepository.save(pendingUser);
+
+        log.info("Pending user saved successfully: studentNumber = {}", pendingUser.getStudentNumber());
     }
 }

--- a/src/main/java/com/mjsec/lms/service/AuthService.java
+++ b/src/main/java/com/mjsec/lms/service/AuthService.java
@@ -68,7 +68,7 @@ public class AuthService {
 
     /**
      * 회원가입 승인 요청을 처리하는 메소드
-     * @param registerRequest 유저의 개인 정보를 담은 Dto
+     * @param registerRequest 유저의 개인 정보를 담은 Dto (학번, 이름, 비밀번호, 이메일, 전화번호)
      */
     public void register(AuthDto.Register registerRequest){
 

--- a/src/main/java/com/mjsec/lms/service/JwtService.java
+++ b/src/main/java/com/mjsec/lms/service/JwtService.java
@@ -27,25 +27,16 @@ public class JwtService {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), SIG.HS256.key().build().getAlgorithm());
     }
 
-    public List<String> getRoles(String token) {
+    public String getRole(String token) {
 
-        List<?> roles = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("roles", List.class);
-
-        if (roles != null) {
-            return roles.stream()
-                    .map(Object::toString)
-                    .collect(Collectors.toList());
-        }
-        else {
-            return Collections.emptyList();
-        }
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
     }
 
+    public Long getStudentNumber(String token){
 
-    public String getLoginId(String token){
-
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("loginId", String.class);
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("studentNumber", Long.class);
     }
+
     public Boolean isExpired(String token) {
 
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
@@ -73,17 +64,17 @@ public class JwtService {
      * JWT 생성
      *
      * @param tokenType : 토큰 타입(ACCESS 토큰 / REFRESH 토큰)
-     * @param loginId : 유저의 로그인 id
-     * @param roles : 유저의 권한 -> 일단 Enum 타입으로 수정함.
+     * @param studentNumber : 유저의 학번
+     * @param role : 유저의 권한
      * @param expiredMs : 만료 시점
      * @return JWT
      */
-    public String createJwt(String tokenType, String loginId, List<String> roles, Long expiredMs) {
+    public String createJwt(String tokenType, Long studentNumber, String role, Long expiredMs) {
 
         return Jwts.builder()
                 .claim("tokenType", tokenType)
-                .claim("loginId", loginId)
-                .claim("roles", roles)
+                .claim("studentNumber", studentNumber)
+                .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)

--- a/src/main/java/com/mjsec/lms/service/JwtService.java
+++ b/src/main/java/com/mjsec/lms/service/JwtService.java
@@ -1,0 +1,92 @@
+package com.mjsec.lms.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtService {
+
+    private SecretKey secretKey;
+
+    @Autowired
+    public JwtService(@Value("${spring.jwt.secret}") String secret){
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public List<String> getRoles(String token) {
+
+        List<?> roles = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("roles", List.class);
+
+        if (roles != null) {
+            return roles.stream()
+                    .map(Object::toString)
+                    .collect(Collectors.toList());
+        }
+        else {
+            return Collections.emptyList();
+        }
+    }
+
+
+    public String getLoginId(String token){
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("loginId", String.class);
+    }
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String getTokenType(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("tokenType", String.class);
+    }
+
+    public Date getExpirationDate(String token) {
+
+        Date expDate = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration();
+        log.info("Extracted Expiration Date from JWT: {}", expDate);
+
+        return expDate;
+    }
+
+    /**
+     * JWT 생성
+     *
+     * @param tokenType : 토큰 타입(ACCESS 토큰 / REFRESH 토큰)
+     * @param loginId : 유저의 로그인 id
+     * @param roles : 유저의 권한 -> 일단 Enum 타입으로 수정함.
+     * @param expiredMs : 만료 시점
+     * @return JWT
+     */
+    public String createJwt(String tokenType, String loginId, List<String> roles, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("tokenType", tokenType)
+                .claim("loginId", loginId)
+                .claim("roles", roles)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/mjsec/lms/service/JwtService.java
+++ b/src/main/java/com/mjsec/lms/service/JwtService.java
@@ -63,11 +63,11 @@ public class JwtService {
     /**
      * JWT 생성
      *
-     * @param tokenType : 토큰 타입(ACCESS 토큰 / REFRESH 토큰)
+     * @param tokenType : 토큰 타입(ACCESS 토큰 / REFRESH 토큰) -> 현재는 ACCESS 토큰만 사용
      * @param studentNumber : 유저의 학번
      * @param role : 유저의 권한
      * @param expiredMs : 만료 시점
-     * @return JWT
+     * @return JWT (String)
      */
     public String createJwt(String tokenType, Long studentNumber, String role, Long expiredMs) {
 

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호를 잘못 입력하셨습니다. 다시 입력해주세요."),
 
     //유저
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.")
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+    ALREADY_REGISTERED_USER(HttpStatus.BAD_REQUEST, "이미 회원가입이 완료된 유저입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
 
     // 학번 관련 에러
+    DUPLICATE_STUDENT_NUMBER(HttpStatus.CONFLICT, "사용할 수 없는 학번 입니다."),
     INVALID_STUDENT_NUMBER(HttpStatus.BAD_REQUEST, "학번은 8자리 숫자 입니다."),
 
     // 이메일 관련 에러

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -1,0 +1,42 @@
+package com.mjsec.lms.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    //General Errors
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
+
+    // 학번 관련 에러
+    INVALID_STUDENT_NUMBER(HttpStatus.BAD_REQUEST, "학번은 8자리 숫자 입니다."),
+
+    // 이메일 관련 에러
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다."),
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "이메일 형식에 맞지 않습니다."),
+    UNAUTHORIZED_EMAIL(HttpStatus.BAD_REQUEST, "정해진 이메일 도메인이 아닙니다."),
+    EMAIL_VERIFICATION_PENDING(HttpStatus.UNAUTHORIZED, "이메일 인증이 완료되지 않았습니다. 인증을 진행해주세요."),
+    FAILED_VERIFICATION(HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않거나 만료되었습니다."),
+    AUTH_ATTEMPT_EXCEEDED(HttpStatus.BAD_REQUEST, "인증 횟수를 초과했습니다. 다시 시도해주세요."),
+    EMPTY_EMAIL(HttpStatus.BAD_REQUEST, "이메일을 입력해주세요."),
+
+    // 비밀번호 관련 에러
+    EMPTY_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호를 입력해주세요."),
+    INVALID_PASSWORD_LENGTH_MIN(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자 이상이어야 합니다."),
+    INVALID_PASSWORD_LENGTH_MAX(HttpStatus.BAD_REQUEST, "비밀번호는 32자 이하로 입력해주세요."),
+    INVALID_PASSWORD_WHITESPACE(HttpStatus.BAD_REQUEST, "비밀번호에 공백을 포함할 수 없습니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호는 소문자, 대문자, 숫자 및 특수문자(!@#$%^&*)를 모두 포함해야 합니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호를 잘못 입력하셨습니다. 다시 입력해주세요."),
+
+    //유저
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String description;
+}

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_REQUEST_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 요청 포맷입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
 
     // 학번 관련 에러

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -1,0 +1,20 @@
+package com.mjsec.lms.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    // Auth 관련
+    SIGNUP_SUCCESS("회원가입 성공"),
+    LOGIN_SUCCESS("로그인 성공"),
+    LOGOUT_SUCCESS("로그아웃 성공"),
+    STUDENT_NUMBER_CHECK_SUCCESS("사용 가능한 학번"),
+    DUPLICATE_STUDENT_NUMBER("사용 중인 학번")
+    ;
+
+    private final String message;
+}

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -15,7 +15,11 @@ public enum ResponseMessage {
     STUDENT_NUMBER_CHECK_SUCCESS("사용 가능한 학번"),
     DUPLICATE_STUDENT_NUMBER("사용 중인 학번"),
     EMAIL_CHECL_SUCCESS("사용 가능한 이메일"),
-    DUPLICATE_EMAIL("사용 중인 이메일")
+    DUPLICATE_EMAIL("사용 중인 이메일"),
+
+    // Admin 관련
+    GET_ALL_PENDING_USER_SUCCESS("회원가입 승인 대기자 목록 반환 성공"),
+    APPROVE_REGISTER_SUCCESS("회원가입 승인 완료")
     ;
 
     private final String message;

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ResponseMessage {
 
     // Auth 관련
-    SIGNUP_SUCCESS("회원가입 성공"),
+    REGISTER_SUCCESS("회원가입 요청 성공"),
     LOGIN_SUCCESS("로그인 성공"),
     LOGOUT_SUCCESS("로그아웃 성공"),
     STUDENT_NUMBER_CHECK_SUCCESS("사용 가능한 학번"),

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -13,7 +13,9 @@ public enum ResponseMessage {
     LOGIN_SUCCESS("로그인 성공"),
     LOGOUT_SUCCESS("로그아웃 성공"),
     STUDENT_NUMBER_CHECK_SUCCESS("사용 가능한 학번"),
-    DUPLICATE_STUDENT_NUMBER("사용 중인 학번")
+    DUPLICATE_STUDENT_NUMBER("사용 중인 학번"),
+    EMAIL_CHECL_SUCCESS("사용 가능한 이메일"),
+    DUPLICATE_EMAIL("사용 중인 이메일")
     ;
 
     private final String message;

--- a/src/main/java/com/mjsec/lms/type/UserRole.java
+++ b/src/main/java/com/mjsec/lms/type/UserRole.java
@@ -1,0 +1,6 @@
+package com.mjsec.lms.type;
+
+public enum UserRole {
+    ROLE_USER,
+    ROLE_ADMIN
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,4 +52,4 @@ springdoc:
 
 admin:
   number: ${ADMIN_NUMBER}
-  password: ${ADMIN_USER_PASSWORD}
+  password: ${ADMIN_PASSWORD}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,3 +49,7 @@ springdoc:
   default-produces-media-type: application/json
   paths-to-match:
     - /**
+
+admin:
+  number: ${ADMIN_NUMBER}
+  password: ${ADMIN_USER_PASSWORD}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,19 +4,6 @@ spring:
       host: localhost
       port: 6379
 
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${GMAIL_USERNAME}  # Gmail 주소
-    password: ${GMAIL_APP_PASSWORD}   # 앱 비밀번호 사용
-    properties:
-      mail:
-        debug: true
-        smtp:
-          auth: true
-          starttls:
-            enable: true
-
   jwt:
     secret: ${JWT_SECRET}
   datasource:


### PR DESCRIPTION
## ⭐️ 변경 사항

- Authentication 기능 개발을 위해 총 7개의 api가 생겼습니다.
<img width="290" height="232" alt="스크린샷 2025-07-23 오후 9 43 09" src="https://github.com/user-attachments/assets/84924ef7-f841-487b-b1e1-db4cf85a21fd" />


- 회원가입 승인을 기다리는 사용자를 위해 PendingUser 엔티티를 만들었습니다. (승인이 이루어지면 User 엔티티에 정보 저장) 따라서, ERD의 수정이 있었습니다.
<img width="1470" height="798" alt="스크린샷 2025-07-23 오후 9 58 49" src="https://github.com/user-attachments/assets/c91b4ec4-a5e6-40a4-81ae-1ab0765a865b" />


- 일반 유저가 회원가입 -> 로그인 -> 로그아웃을 이용하는 과정은 다음과 같습니다.
1. 유저의 학번, 이름, 비밀번호, 이메일, 전화번호를 회원가입 폼(프론트)에 입력 (학번, 이메일 중복 확인 API 사용)
2. 회원가입 신청 버튼 클릭 (POST : /api/v1/auth/register)
3. Admin(lms 관리자)는 회원가입 승인 대기 목록을 조회 (GET : /api/v1/admin/member-approval)
4. Admin(lms 관리자)는 회원가입 승인 대기 목록에서 특정 학번의 사용자를 승인 (POST : /api/v1/admin/member-approval/{studentNumber})
5. 유저 로그인 (POST : /api/v1/auth/login)
6. 유저 로그아웃 (POST : /api/v1/auth/login)


## 📌 Notification 

- 초기 세팅 방법은 노션을 통해 공지가 나갈 예정 (jdk / gradle 설정, db 연결, application.yml 파일 환경변수 세팅)


- JWT : 현재는 만료시간 12시간인 access token만 사용. refresh token은 사용 고려중. (만약 refresh 토큰을 도입한다면, access token 만료시간은 1시간, refresh token 만료 시간은 12시간으로 잡을 예정. access token은 헤더에, refresh token은 redis에서 관리 예정)


- API docs를 위한 swagger는 명세서에 있는 모든 API 완성 후 마지막에 붙일 예정. 
- Controller를 제외한 나머지 layer에서 주석 성실히 달기. 
ex)
<img width="801" height="332" alt="스크린샷 2025-07-23 오후 10 02 09" src="https://github.com/user-attachments/assets/bb6898d8-d894-4391-988e-010760a32aed" />
<img width="689" height="240" alt="스크린샷 2025-07-23 오후 10 02 34" src="https://github.com/user-attachments/assets/e773467b-a154-4aed-aaa5-07011294d703" />
- log.info, log.warn 사용하기 (System.out.println은 테스트만을 위해 사용)
ex)
<img width="891" height="130" alt="스크린샷 2025-07-23 오후 10 04 16" src="https://github.com/user-attachments/assets/4656934a-fc8d-4561-b823-93e54d54482b" />
<img width="616" height="229" alt="스크린샷 2025-07-23 오후 10 04 32" src="https://github.com/user-attachments/assets/8ee7b0f3-e0b5-4e4b-bdc3-e324680b4527" />

## 🖥️ 테스트
- 테스트 방법 : Postman

- 학번 중복 확인
<img width="1408" height="946" alt="스크린샷 2025-07-23 오후 10 06 18" src="https://github.com/user-attachments/assets/d002a4ab-f8dc-4222-a974-cdcdd09feea7" />

- 이메일 중복 확인
<img width="1408" height="946" alt="스크린샷 2025-07-23 오후 10 06 37" src="https://github.com/user-attachments/assets/f93dc4bd-e891-4ea4-9881-a45115ab6669" />

- 회원가입 승인 요청
<img width="1408" height="946" alt="스크린샷 2025-07-23 오후 10 07 02" src="https://github.com/user-attachments/assets/aa95cc55-1729-4c1c-9f5f-4d1abae1ae10" />

- (Admin 권한 필요 -> 테스트전 로그인하여 토큰을 헤더에 넣어주어야 함) 회원가입 승인 대기자 목록 조회
<img width="1408" height="946" alt="스크린샷 2025-07-23 오후 10 08 01" src="https://github.com/user-attachments/assets/cdfb88c4-02b6-4835-acc1-8d14f3370e54" />

- (Admin 권한 필요 -> 테스트전 로그인하여 토큰을 헤더에 넣어주어야 함) 회원가입 승인
<img width="1408" height="946" alt="스크린샷 2025-07-23 오후 10 08 24" src="https://github.com/user-attachments/assets/26f2f86d-70ed-445c-bedd-d57e16ba5cfb" />

- 로그인 (테스트 단계에서는 토큰이 응답 Body에도 보여지도록 함)
<img width="1408" height="946" alt="스크린샷 2025-07-23 오후 10 08 39" src="https://github.com/user-attachments/assets/d3aaaab7-f7b4-40a0-a5aa-86ff1d71b0ef" />

- 로그아웃 (아직 Refresh 토큰을 사용하지 않기 때문에 별도의 액션을 하지는 않음. API 요청시 토큰 유효성만 검사.)
<img width="1408" height="946" alt="스크린샷 2025-07-23 오후 10 09 48" src="https://github.com/user-attachments/assets/89a67f98-b285-4729-9775-c0e718dd9bdb" />