### PR TITLE
Feat/get assignment (전체 과제 조회)

### DIFF
--- a/src/main/java/com/mjsec/lms/config/SecurityConfig.java
+++ b/src/main/java/com/mjsec/lms/config/SecurityConfig.java
@@ -74,6 +74,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/swagger-ui/*", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/groups/**").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/v1/users/**").permitAll() // 임시로 허용
                 );

--- a/src/main/java/com/mjsec/lms/controller/AssignmentController.java
+++ b/src/main/java/com/mjsec/lms/controller/AssignmentController.java
@@ -2,12 +2,15 @@ package com.mjsec.lms.controller;
 
 
 import com.mjsec.lms.dto.AssignmentDTO;
+import com.mjsec.lms.dto.AssignmentResponse;
 import com.mjsec.lms.dto.SuccessResponse;
 import com.mjsec.lms.service.AssignmentService;
 import com.mjsec.lms.type.ResponseMessage;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/groups")
@@ -19,8 +22,8 @@ public class AssignmentController {
         this.assignmentService = assignmentService;
     }
 
-    @PostMapping("/{groupId}/assignments")
-    public ResponseEntity<SuccessResponse<AssignmentDTO>> createAssignment(
+    @PostMapping("/{groupId}/create-assignment")
+    public ResponseEntity<SuccessResponse<AssignmentResponse>> createAssignment(
             @PathVariable Long groupId,
             @RequestBody AssignmentDTO dto,
             Authentication authentication) {  // Spring Security가 자동 주입
@@ -28,14 +31,31 @@ public class AssignmentController {
         // JwtFilter에서 설정한 studentNumber를 가져옴
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();
 
-        assignmentService.createAssignment(groupId, dto, currentUserStudentNumber);
+        AssignmentResponse response = assignmentService.createAssignment(groupId, dto, currentUserStudentNumber);
 
         return ResponseEntity.ok(
                 SuccessResponse.of(
                         ResponseMessage.ASSIGNMENT_SUCCESS,
-                        dto
+                        response
                 )
         );
     }
 
+    @GetMapping("/{groupId}/assignments")
+    public ResponseEntity<SuccessResponse<List<AssignmentResponse>>> getAssignments(
+            @PathVariable Long groupId,
+            Authentication authentication){
+
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        List<AssignmentResponse> assignmentResponseList = assignmentService.getAssignment(groupId,currentUserStudentNumber);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.ASSIGNMENT_SUCCESS,
+                        assignmentResponseList
+                )
+        );
+    }
 }

--- a/src/main/java/com/mjsec/lms/controller/AssignmentController.java
+++ b/src/main/java/com/mjsec/lms/controller/AssignmentController.java
@@ -1,0 +1,41 @@
+package com.mjsec.lms.controller;
+
+
+import com.mjsec.lms.dto.AssignmentDTO;
+import com.mjsec.lms.dto.SuccessResponse;
+import com.mjsec.lms.service.AssignmentService;
+import com.mjsec.lms.type.ResponseMessage;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/groups")
+public class AssignmentController {
+
+    private final AssignmentService assignmentService;
+
+    public AssignmentController(AssignmentService assignmentService) {
+        this.assignmentService = assignmentService;
+    }
+
+    @PostMapping("/{groupId}/assignments")
+    public ResponseEntity<SuccessResponse<AssignmentDTO>> createAssignment(
+            @PathVariable Long groupId,
+            @RequestBody AssignmentDTO dto,
+            Authentication authentication) {  // Spring Security가 자동 주입
+
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        assignmentService.createAssignment(groupId, dto, currentUserStudentNumber);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.ASSIGNMENT_SUCCESS,
+                        dto
+                )
+        );
+    }
+
+}

--- a/src/main/java/com/mjsec/lms/domain/GroupMember.java
+++ b/src/main/java/com/mjsec/lms/domain/GroupMember.java
@@ -1,0 +1,42 @@
+package com.mjsec.lms.domain;
+
+import com.mjsec.lms.type.GroupMemberRole;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "group_member")
+@SuperBuilder
+@SQLDelete(sql = "UPDATE group_member SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at is null")
+public class GroupMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    private GroupMemberRole role = GroupMemberRole.MENTEE;
+
+    @Builder.Default
+    @Column(name = "warn", nullable = false)
+    private Integer warn = 0;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id")
+    private StudyGroup studyGroup;
+}

--- a/src/main/java/com/mjsec/lms/dto/AssignmentDTO.java
+++ b/src/main/java/com/mjsec/lms/dto/AssignmentDTO.java
@@ -1,0 +1,20 @@
+package com.mjsec.lms.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class AssignmentDTO {
+
+    private String title;
+
+    private String content;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+
+}

--- a/src/main/java/com/mjsec/lms/dto/AssignmentResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/AssignmentResponse.java
@@ -1,0 +1,22 @@
+package com.mjsec.lms.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class AssignmentResponse {
+    private Long assignmentId;
+
+    private String title;
+
+    private String content;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/mjsec/lms/repository/AssignmentRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/AssignmentRepository.java
@@ -1,0 +1,10 @@
+package com.mjsec.lms.repository;
+
+import com.mjsec.lms.domain.Assignment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
+
+}

--- a/src/main/java/com/mjsec/lms/repository/AssignmentRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/AssignmentRepository.java
@@ -4,7 +4,10 @@ import com.mjsec.lms.domain.Assignment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
 
+    List<Assignment> findAllByStudyGroup_StudyId(Long studyId);
 }

--- a/src/main/java/com/mjsec/lms/repository/GroupMemberRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/GroupMemberRepository.java
@@ -1,6 +1,8 @@
 package com.mjsec.lms.repository;
 
 import com.mjsec.lms.domain.GroupMember;
+import com.mjsec.lms.domain.StudyGroup;
+import com.mjsec.lms.domain.User;
 import com.mjsec.lms.type.GroupMemberRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,4 +14,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 
     @Query("SELECT gm.role FROM GroupMember gm WHERE gm.user.userId = :userId AND gm.studyGroup.studyId = :studyId")
     Optional<GroupMemberRole> findRoleByUserIdAndStudyId(@Param("userId") Long userId, @Param("studyId") Long studyId);
+
+    Optional<GroupMember> findByUserAndStudyGroup(User user, StudyGroup studyGroup);
 }

--- a/src/main/java/com/mjsec/lms/repository/GroupMemberRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/GroupMemberRepository.java
@@ -1,0 +1,15 @@
+package com.mjsec.lms.repository;
+
+import com.mjsec.lms.domain.GroupMember;
+import com.mjsec.lms.type.GroupMemberRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+
+    @Query("SELECT gm.role FROM GroupMember gm WHERE gm.user.userId = :userId AND gm.studyGroup.studyId = :studyId")
+    Optional<GroupMemberRole> findRoleByUserIdAndStudyId(@Param("userId") Long userId, @Param("studyId") Long studyId);
+}

--- a/src/main/java/com/mjsec/lms/repository/StudyGroupRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/StudyGroupRepository.java
@@ -1,0 +1,8 @@
+package com.mjsec.lms.repository;
+
+import com.mjsec.lms.domain.StudyGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
+
+}

--- a/src/main/java/com/mjsec/lms/repository/SubmissionRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/SubmissionRepository.java
@@ -1,0 +1,10 @@
+package com.mjsec.lms.repository;
+
+import com.mjsec.lms.domain.AssignmentSubmission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SubmissionRepository extends JpaRepository<AssignmentSubmission, Long> {
+
+}

--- a/src/main/java/com/mjsec/lms/service/AssignmentService.java
+++ b/src/main/java/com/mjsec/lms/service/AssignmentService.java
@@ -1,0 +1,77 @@
+package com.mjsec.lms.service;
+
+import com.mjsec.lms.domain.Assignment;
+import com.mjsec.lms.domain.StudyGroup;
+import com.mjsec.lms.domain.User;
+import com.mjsec.lms.dto.AssignmentDTO;
+import com.mjsec.lms.exception.RestApiException;
+import com.mjsec.lms.repository.AssignmentRepository;
+import com.mjsec.lms.repository.GroupMemberRepository;
+import com.mjsec.lms.repository.StudyGroupRepository;
+import com.mjsec.lms.repository.UserRepository;
+import com.mjsec.lms.type.ErrorCode;
+import com.mjsec.lms.type.GroupMemberRole;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+public class AssignmentService {
+    private final AssignmentRepository assignmentRepository;
+    private final UserRepository userRepository;
+    private final StudyGroupRepository studyGroupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    public AssignmentService(AssignmentRepository assignmentRepository,
+                             UserRepository userRepository,
+                             StudyGroupRepository studyGroupRepository,
+                             GroupMemberRepository groupMemberRepository
+    ) {
+
+        this.assignmentRepository = assignmentRepository;
+        this.userRepository = userRepository;
+        this.studyGroupRepository = studyGroupRepository;
+        this.groupMemberRepository = groupMemberRepository;
+    }
+
+    //과제 등록하기 (멘토만 가능함.)
+    public void createAssignment(Long groupId, AssignmentDTO dto , Long currentUserStudentNumber) {
+
+        log.info("createAssignment called with groupId: {}, dto: {}, currentUserStudentNumber: {}", groupId, dto, currentUserStudentNumber);
+
+        //현재 과제를 생성하려는 유저 확인하기
+        User user = userRepository.findByStudentNumber(currentUserStudentNumber).orElseThrow(()-> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+        //스터디가 존재하는 지 확인하기
+        StudyGroup studyGroup = studyGroupRepository.findById(groupId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_NOT_FOUND));
+
+        //스터디에 등록되어 있는지 (멘토, 멘티 역할이 있는가?)
+        GroupMemberRole userRole = groupMemberRepository.findRoleByUserIdAndStudyId(user.getUserId(), groupId).orElseThrow(() -> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
+
+        // 멘토 권한 확인
+        if (userRole != GroupMemberRole.MENTO) {
+            log.warn("User {} does not have MENTOR role in StudyGroup {}. Current role: {}",
+                    user.getUserId(), groupId, userRole);
+            throw new RestApiException(ErrorCode.UNAUTHORIZED_ROLE);
+        }
+
+        log.info("User {} is confirmed as MENTOR of StudyGroup: {}", user.getUserId(), studyGroup.getName());
+
+        //데이터 넣기
+        Assignment assignment = Assignment.builder()
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .startDate(dto.getStartDate())
+                .endDate(dto.getEndDate())
+                .creator(user)
+                .studyGroup(studyGroup)
+                .build();
+
+        log.info("Assignment created successfully: {}", assignment);
+
+        assignmentRepository.save(assignment);
+    }
+}

--- a/src/main/java/com/mjsec/lms/service/AssignmentService.java
+++ b/src/main/java/com/mjsec/lms/service/AssignmentService.java
@@ -1,9 +1,11 @@
 package com.mjsec.lms.service;
 
 import com.mjsec.lms.domain.Assignment;
+import com.mjsec.lms.domain.GroupMember;
 import com.mjsec.lms.domain.StudyGroup;
 import com.mjsec.lms.domain.User;
 import com.mjsec.lms.dto.AssignmentDTO;
+import com.mjsec.lms.dto.AssignmentResponse;
 import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.repository.AssignmentRepository;
 import com.mjsec.lms.repository.GroupMemberRepository;
@@ -15,6 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -37,7 +41,7 @@ public class AssignmentService {
     }
 
     //과제 등록하기 (멘토만 가능함.)
-    public void createAssignment(Long groupId, AssignmentDTO dto , Long currentUserStudentNumber) {
+    public AssignmentResponse createAssignment(Long groupId, AssignmentDTO dto , Long currentUserStudentNumber) {
 
         log.info("createAssignment called with groupId: {}, dto: {}, currentUserStudentNumber: {}", groupId, dto, currentUserStudentNumber);
 
@@ -68,10 +72,58 @@ public class AssignmentService {
                 .endDate(dto.getEndDate())
                 .creator(user)
                 .studyGroup(studyGroup)
+                .createdAt(LocalDateTime.now())
                 .build();
 
         log.info("Assignment created successfully: {}", assignment);
 
         assignmentRepository.save(assignment);
+
+        return createResponse(assignment);
+    }
+
+    public List<AssignmentResponse> getAssignment(Long groupId, Long currentUserStudentNumber) {
+
+        log.info("getAssignment called");
+
+        //전체 과제를 조회하려는 유저 확인하기
+        User user = userRepository.findByStudentNumber(currentUserStudentNumber).orElseThrow(()-> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+        //스터디가 존재하는 지 확인하기
+        StudyGroup studyGroup = studyGroupRepository.findById(groupId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_NOT_FOUND));
+
+        //스터디 그룹에 속하는 유저인지 확인하기
+        GroupMember groupMember = groupMemberRepository.findByUserAndStudyGroup(user,studyGroup).orElseThrow(()-> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
+
+        //전체 과제 조회하기
+        List<Assignment> assignmentList = assignmentRepository.findAllByStudyGroup_StudyId(groupId);
+
+        log.info("Found {} assignments in StudyGroup: {}", assignmentList.size(), studyGroup.getName());
+
+        //Assignment Response로 변환하기
+        List<AssignmentResponse> assignmentResponses = new ArrayList<>();
+        for(Assignment assignment : assignmentList){
+            assignmentResponses.add(createResponse(assignment));
+        }
+
+        log.info("get Assignment Successfully!");
+
+        return assignmentResponses;
+    }
+
+    //과제 Response로 변환하기
+    private AssignmentResponse createResponse(Assignment assignment) {
+
+        AssignmentResponse response = AssignmentResponse.builder()
+                .assignmentId(assignment.getAssignId())
+                .title(assignment.getTitle())
+                .content(assignment.getContent())
+                .startDate(assignment.getStartDate())
+                .endDate(assignment.getEndDate())
+                .createdAt(assignment.getCreatedAt())
+                .build();
+
+        return response;
     }
 }

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -37,7 +37,13 @@ public enum ErrorCode {
 
     //유저
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
-    ALREADY_REGISTERED_USER(HttpStatus.BAD_REQUEST, "이미 회원가입이 완료된 유저입니다.")
+    ALREADY_REGISTERED_USER(HttpStatus.BAD_REQUEST, "이미 회원가입이 완료된 유저입니다."),
+
+
+    //스터디
+    STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
+    UNAUTHORIZED_ROLE(HttpStatus.UNAUTHORIZED, "멘토만 과제를 등록할 수 있습니다."),
+    STUDY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스터디 멤버를 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/mjsec/lms/type/GroupMemberRole.java
+++ b/src/main/java/com/mjsec/lms/type/GroupMemberRole.java
@@ -1,0 +1,6 @@
+package com.mjsec.lms.type;
+
+public enum GroupMemberRole {
+    MENTO,
+    MENTEE
+}

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -19,7 +19,10 @@ public enum ResponseMessage {
 
     // Admin 관련
     GET_ALL_PENDING_USER_SUCCESS("회원가입 승인 대기자 목록 반환 성공"),
-    APPROVE_REGISTER_SUCCESS("회원가입 승인 완료")
+    APPROVE_REGISTER_SUCCESS("회원가입 승인 완료"),
+
+    // Assignment 관련
+    ASSIGNMENT_SUCCESS("과제 등록 성공")
     ;
 
     private final String message;


### PR DESCRIPTION
### 전체 과제 조회 기능

해당 스터디에 등록된 과제들을 모두 반환합니다.
프론트엔드 측에서 필요하다면, Pageable 을 추가할 계획입니다.

**전체 과제 조회 조건**
- 해당 스터디에 등록된 유저여야 함. (멘토, 멘티 역할을 가진 스터디 멤버여야 한다.)
- 해당 스터디가 존재해야 한다.

**테스트**

전체 과제 조회
<img width="915" height="928" alt="image" src="https://github.com/user-attachments/assets/8f140fb9-a129-4082-a56f-71b61652f660" />

해당 스터디 멤버를 찾을 수 없는 경우
<img width="906" height="510" alt="image" src="https://github.com/user-attachments/assets/e7ab7496-b1b2-4d52-b815-3a0d3078114d" />

스터디가 존재하지 않는 경우
<img width="913" height="568" alt="image" src="https://github.com/user-attachments/assets/a600621d-c1b6-4f3a-a57d-332bdece2848" />

### 그 외 수정사항

과제 등록하기 API를 `/api/v1/groups/{id}/create-assignment` 로 수정했습니다.

createdAt 이 NULL로 표기되던 것을 일단은 과제 등록하기에서 now() 로 등록해줬습니다.

```Java
//데이터 넣기
Assignment assignment = Assignment.builder()
        .title(dto.getTitle())
        .content(dto.getContent())
        .startDate(dto.getStartDate())
        .endDate(dto.getEndDate())
        .creator(user)
        .studyGroup(studyGroup)
        .createdAt(LocalDateTime.now())
        .build();
```

땡큐 풜 와칭 디스

코드 리뷰, 코멘트 적극 달아주세용
<img width="287" height="176" alt="image" src="https://github.com/user-attachments/assets/b464b256-014f-407d-a29c-3ebf967381d7" />


