### PR TITLE
Feat: 과제 제출하기 (멘티용) + Fix: 에러 처리, 코드 컨벤션

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/AssignmentController.java
+++ b/src/main/java/com/mjsec/lms/controller/AssignmentController.java
@@ -1,12 +1,10 @@
 package com.mjsec.lms.controller;
 
 
-import com.mjsec.lms.dto.AssignmentDTO;
-import com.mjsec.lms.dto.AssignmentResponse;
-import com.mjsec.lms.dto.DetailAssignmentResponse;
-import com.mjsec.lms.dto.SuccessResponse;
+import com.mjsec.lms.dto.*;
 import com.mjsec.lms.service.AssignmentService;
 import com.mjsec.lms.type.ResponseMessage;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -23,10 +21,11 @@ public class AssignmentController {
         this.assignmentService = assignmentService;
     }
 
+    //과제 등록하기
     @PostMapping("/{groupId}/create-assignment")
     public ResponseEntity<SuccessResponse<DetailAssignmentResponse>> createAssignment(
             @PathVariable Long groupId,
-            @RequestBody AssignmentDTO dto,
+            @Valid @RequestBody AssignmentDto dto,
             Authentication authentication) {  // Spring Security가 자동 주입
 
         // JwtFilter에서 설정한 studentNumber를 가져옴
@@ -81,11 +80,12 @@ public class AssignmentController {
         );
     }
 
+    //등록한 과제 수정하기
     @PutMapping("/{groupId}/assignments/{assignId}")
     public ResponseEntity<SuccessResponse<DetailAssignmentResponse>> updateAssignment(
             @PathVariable Long groupId,
             @PathVariable Long assignId,
-            @RequestBody AssignmentDTO dto,
+            @RequestBody AssignmentDto dto,
             Authentication authentication){
 
         // JwtFilter에서 설정한 studentNumber를 가져옴
@@ -101,6 +101,7 @@ public class AssignmentController {
         );
     }
 
+    //등록한 과제 삭제하기
     @DeleteMapping("/{groupId}/assignments/{assignId}")
     public ResponseEntity<SuccessResponse<Void>> deleteAssignment(
             @PathVariable Long groupId,
@@ -115,6 +116,27 @@ public class AssignmentController {
         return ResponseEntity.ok(
                 SuccessResponse.of(
                         ResponseMessage.ASSIGNMENT_DELETE_SUCCESS
+                )
+        );
+    }
+
+    //과제 제출하기 (멘티가)
+    @PostMapping("/{groupId}/assign-submit/{assignId}")
+    public ResponseEntity<SuccessResponse<SubmissionResponse>> submitAssignment(
+            @Valid @RequestBody SubmissionDto dto,
+            @PathVariable Long groupId,
+            @PathVariable Long assignId,
+            Authentication authentication){
+
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        SubmissionResponse submissionResponse = assignmentService.submitAssignment(groupId,assignId,currentUserStudentNumber,dto);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.ASSIGNMENT_SUBMIT_SUCCESS,
+                        submissionResponse
                 )
         );
     }

--- a/src/main/java/com/mjsec/lms/domain/Assignment.java
+++ b/src/main/java/com/mjsec/lms/domain/Assignment.java
@@ -49,4 +49,8 @@ public class Assignment extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "assignment", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<AssignmentSubmission> submissions = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "assignment", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<AssignmentComment> comments = new ArrayList<>();
 }

--- a/src/main/java/com/mjsec/lms/domain/AssignmentComment.java
+++ b/src/main/java/com/mjsec/lms/domain/AssignmentComment.java
@@ -1,0 +1,44 @@
+package com.mjsec.lms.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "assignment_comment")
+@SuperBuilder
+@SQLDelete(sql = "UPDATE assignment_comment SET deleted_at = NOW() WHERE comment_id = ?")
+@SQLRestriction("deleted_at is null")
+public class AssignmentComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assign_id")
+    private Assignment assignment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User author;
+
+    /* 나중에 답글 개념까지 추가한다면 쓰일 변수
+    @Builder.Default
+    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<AssignmentComment> replies = new ArrayList<>();
+     */
+}

--- a/src/main/java/com/mjsec/lms/domain/AssignmentSubmission.java
+++ b/src/main/java/com/mjsec/lms/domain/AssignmentSubmission.java
@@ -13,21 +13,23 @@ import org.hibernate.annotations.SQLRestriction;
 @AllArgsConstructor
 @Table(name = "assignment_submission")
 @SuperBuilder
-@SQLDelete(sql = "UPDATE assignment_submission SET deleted_at = NOW() WHERE id = ?")
+@SQLDelete(sql = "UPDATE assignment_submission SET deleted_at = NOW() WHERE submission_id = ?")
 @SQLRestriction("deleted_at is null")
 public class AssignmentSubmission extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    private Long id;
+    @Column(name = "submission_id")
+    private Long submissionId;
 
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
+    /* 파일 올리기 X - 일단 지움
     @Column(name = "file_url", columnDefinition = "TEXT")
     private String fileUrl;
-
+     */
+    
     @Column(name = "feedback", columnDefinition = "TEXT")
     private String feedback;
 

--- a/src/main/java/com/mjsec/lms/domain/GroupMember.java
+++ b/src/main/java/com/mjsec/lms/domain/GroupMember.java
@@ -14,14 +14,14 @@ import org.hibernate.annotations.SQLRestriction;
 @AllArgsConstructor
 @Table(name = "group_member")
 @SuperBuilder
-@SQLDelete(sql = "UPDATE group_member SET deleted_at = NOW() WHERE id = ?")
+@SQLDelete(sql = "UPDATE group_member SET deleted_at = NOW() WHERE member_id = ?")
 @SQLRestriction("deleted_at is null")
 public class GroupMember extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    private Long id;
+    @Column(name = "member_id")
+    private Long memberId;
 
     @Builder.Default
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/mjsec/lms/dto/AssignmentDto.java
+++ b/src/main/java/com/mjsec/lms/dto/AssignmentDto.java
@@ -1,0 +1,25 @@
+package com.mjsec.lms.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class AssignmentDto {
+
+    @NotBlank(message = "제목을 입력해주세요!")
+    private String title;
+
+    @NotBlank(message = "내용을 입력해주세요!")
+    private String content;
+
+    @NotNull(message = "시작일자는 필수입니다!")
+    private LocalDateTime startDate;
+
+    @NotNull(message = "종료일자는 필수입니다!")
+    private LocalDateTime endDate;
+}

--- a/src/main/java/com/mjsec/lms/dto/SubmissionDto.java
+++ b/src/main/java/com/mjsec/lms/dto/SubmissionDto.java
@@ -1,0 +1,11 @@
+package com.mjsec.lms.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class SubmissionDto {
+
+    @NotBlank(message = "과제 내용을 입력해주세요!")
+    private String content;
+}

--- a/src/main/java/com/mjsec/lms/dto/SubmissionResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/SubmissionResponse.java
@@ -7,14 +7,12 @@ import java.time.LocalDateTime;
 
 @Data
 @Builder
-public class AssignmentDTO {
-
-    private String title;
+public class SubmissionResponse {
+    private Long submissionId;
 
     private String content;
 
-    private LocalDateTime startDate;
+    private String creatorName;
 
-    private LocalDateTime endDate;
-
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/mjsec/lms/service/AssignmentService.java
+++ b/src/main/java/com/mjsec/lms/service/AssignmentService.java
@@ -1,17 +1,12 @@
 package com.mjsec.lms.service;
 
 import com.mjsec.lms.domain.Assignment;
-import com.mjsec.lms.domain.GroupMember;
+import com.mjsec.lms.domain.AssignmentSubmission;
 import com.mjsec.lms.domain.StudyGroup;
 import com.mjsec.lms.domain.User;
-import com.mjsec.lms.dto.AssignmentDTO;
-import com.mjsec.lms.dto.AssignmentResponse;
-import com.mjsec.lms.dto.DetailAssignmentResponse;
+import com.mjsec.lms.dto.*;
 import com.mjsec.lms.exception.RestApiException;
-import com.mjsec.lms.repository.AssignmentRepository;
-import com.mjsec.lms.repository.GroupMemberRepository;
-import com.mjsec.lms.repository.StudyGroupRepository;
-import com.mjsec.lms.repository.UserRepository;
+import com.mjsec.lms.repository.*;
 import com.mjsec.lms.type.ErrorCode;
 import com.mjsec.lms.type.GroupMemberRole;
 import lombok.extern.slf4j.Slf4j;
@@ -29,26 +24,32 @@ public class AssignmentService {
     private final UserRepository userRepository;
     private final StudyGroupRepository studyGroupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final SubmissionRepository submissionRepository;
 
     public AssignmentService(AssignmentRepository assignmentRepository,
                              UserRepository userRepository,
                              StudyGroupRepository studyGroupRepository,
-                             GroupMemberRepository groupMemberRepository) {
+                             GroupMemberRepository groupMemberRepository,
+                             SubmissionRepository submissionRepository) {
+
         this.assignmentRepository = assignmentRepository;
         this.userRepository = userRepository;
         this.studyGroupRepository = studyGroupRepository;
         this.groupMemberRepository = groupMemberRepository;
+        this.submissionRepository = submissionRepository;
     }
 
     // 과제 등록하기 (멘토만 가능함.)
-    public DetailAssignmentResponse createAssignment(Long groupId, AssignmentDTO dto, Long currentUserStudentNumber) {
+    @Transactional
+    public DetailAssignmentResponse createAssignment(Long groupId, AssignmentDto dto, Long currentUserStudentNumber) {
+
         log.info("createAssignment called with groupId: {}, dto: {}, currentUserStudentNumber: {}", groupId, dto, currentUserStudentNumber);
 
         User user = validateUser(currentUserStudentNumber);
         StudyGroup studyGroup = validateStudyGroup(groupId);
         validateMentorRole(user.getUserId(), groupId);
 
-        log.info("User {} is confirmed as MENTOR of StudyGroup: {}", user.getUserId(), studyGroup.getName());
+        log.info("User {} is confirmed as MENTO of StudyGroup: {}", user.getUserId(), studyGroup.getName());
 
         Assignment assignment = Assignment.builder()
                 .title(dto.getTitle())
@@ -66,9 +67,10 @@ public class AssignmentService {
         return createDetailAssignmentResponse(assignment);
     }
 
-    @Transactional(readOnly = true)
     // 전체 과제 조회하기
+    @Transactional(readOnly = true)
     public List<AssignmentResponse> getAssignment(Long groupId, Long currentUserStudentNumber) {
+
         log.info("getAssignment called");
 
         User user = validateUser(currentUserStudentNumber);
@@ -87,9 +89,10 @@ public class AssignmentService {
         return assignmentResponses;
     }
 
-    @Transactional(readOnly = true)
     // 과제 상세 조회하기
+    @Transactional(readOnly = true)
     public DetailAssignmentResponse getDetailAssignment(Long groupId, Long assignmentId, Long currentUserStudentNumber) {
+
         log.info("getDetailAssignment called");
 
         User user = validateUser(currentUserStudentNumber);
@@ -101,9 +104,10 @@ public class AssignmentService {
         return createDetailAssignmentResponse(assignment);
     }
 
-    @Transactional
     //과제 수정하기 (멘토만 가능함.)
-    public DetailAssignmentResponse updateAssignment(Long groupId, Long assignmentId, AssignmentDTO dto, Long currentUserStudentNumber) {
+    @Transactional
+    public DetailAssignmentResponse updateAssignment(Long groupId, Long assignmentId, AssignmentDto dto, Long currentUserStudentNumber) {
+
         log.info("updateAssignment called");
 
         User user = validateUser(currentUserStudentNumber);
@@ -117,9 +121,10 @@ public class AssignmentService {
         return createDetailAssignmentResponse(assignment);
     }
 
-    @Transactional
     // 과제 삭제하기 (멘토만 가능함.)
+    @Transactional
     public void deleteAssignment(Long groupId, Long assignmentId, Long currentUserStudentNumber) {
+
         log.info("deleteAssignment called");
 
         User user = validateUser(currentUserStudentNumber);
@@ -133,41 +138,82 @@ public class AssignmentService {
         log.info("Assignment deleted successfully: {}", assignment);
     }
 
+    //과제 제출하기
+    @Transactional
+    public SubmissionResponse submitAssignment(Long groupId, Long assignmentId, Long currentUserStudentNumber, SubmissionDto dto) {
+
+        log.info("submitAssignment called");
+
+        User user = validateUser(currentUserStudentNumber);
+        StudyGroup studyGroup = validateStudyGroup(groupId);
+        validateGroupMembership(user, studyGroup);
+        validateMenteeRole(user.getUserId(), groupId);
+        Assignment assignment = validateAssignment(assignmentId);
+
+        AssignmentSubmission assignmentSubmission = AssignmentSubmission.builder()
+                .content(dto.getContent())
+                .createdAt(LocalDateTime.now())
+                .submitter(user)
+                .assignment(assignment)
+                .build();
+
+        submissionRepository.save(assignmentSubmission);
+        log.info("Assignment submission saved successfully: {}", assignmentSubmission);
+
+        return createSubmissionResponse(assignmentSubmission);
+    }
+
     /**
      * === 검증 메서드들 ===
      */
 
     //사용자 존재 여부를 확인하고 User 객체를 반환
     private User validateUser(Long studentNumber) {
+
         return userRepository.findByStudentNumber(studentNumber)
                 .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
     }
 
     //스터디 그룹 존재 여부를 확인하고 StudyGroup 객체를 반환
     private StudyGroup validateStudyGroup(Long groupId) {
+
         return studyGroupRepository.findById(groupId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_NOT_FOUND));
     }
 
+    private void validateMenteeRole(Long userId, Long groupId) {
+
+        GroupMemberRole userRole = groupMemberRepository.findRoleByUserIdAndStudyId(userId, groupId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
+
+        if(userRole != GroupMemberRole.MENTEE) {
+            log.warn("User {} does not have MENTEE role in StudyGroup {}. Current role: {}", userId, groupId, userRole);
+            throw new RestApiException(ErrorCode.UNAUTHORIZED_MENTEE_ROLE);
+        }
+    }
+
     //사용자가 해당 스터디 그룹의 멘토인지 확인
     private void validateMentorRole(Long userId, Long groupId) {
+
         GroupMemberRole userRole = groupMemberRepository.findRoleByUserIdAndStudyId(userId, groupId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
 
         if (userRole != GroupMemberRole.MENTO) {
-            log.warn("User {} does not have MENTOR role in StudyGroup {}. Current role: {}", userId, groupId, userRole);
-            throw new RestApiException(ErrorCode.UNAUTHORIZED_ROLE);
+            log.warn("User {} does not have MENTO role in StudyGroup {}. Current role: {}", userId, groupId, userRole);
+            throw new RestApiException(ErrorCode.UNAUTHORIZED_MENTO_ROLE);
         }
     }
 
     //사용자가 해당 스터디 그룹의 멤버인지 확인
     private void validateGroupMembership(User user, StudyGroup studyGroup) {
+
         groupMemberRepository.findByUserAndStudyGroup(user, studyGroup)
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
     }
 
-    //Assignment 존재 여부를 확인하고 Assignment 객체를 반환
+    //Assignment(과제) 존재 여부를 확인하고 Assignment 객체를 반환
     private Assignment validateAssignment(Long assignmentId) {
+
         return assignmentRepository.findById(assignmentId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.ASSIGNMENT_NOT_FOUND));
     }
@@ -177,11 +223,29 @@ public class AssignmentService {
      */
 
     //Assignment 데이터를 업데이트
-    private void updateAssignmentData(Assignment assignment, AssignmentDTO dto) {
-        assignment.setTitle(dto.getTitle());
-        assignment.setContent(dto.getContent());
-        assignment.setStartDate(dto.getStartDate());
-        assignment.setEndDate(dto.getEndDate());
+    private void updateAssignmentData(Assignment assignment, AssignmentDto dto) {
+
+        /*
+        null이 아닌 경우만 update 하도록 변경.
+        title과 content는 빈 문자열인지 아닌지까지 검사하기
+         */
+        
+        if (dto.getTitle() != null && !dto.getTitle().trim().isEmpty()) {
+            assignment.setTitle(dto.getTitle());
+        }
+
+        if(dto.getContent() != null && !dto.getContent().trim().isEmpty()){
+            assignment.setContent(dto.getContent());
+        }
+
+        if (dto.getStartDate() != null) {
+            assignment.setStartDate(dto.getStartDate());
+        }
+
+        if (dto.getEndDate() != null) {
+            assignment.setEndDate(dto.getEndDate());
+        }
+
         assignment.setUpdatedAt(LocalDateTime.now());
         assignmentRepository.save(assignment);
         log.info("Assignment updated successfully: {}", assignment);
@@ -193,6 +257,7 @@ public class AssignmentService {
 
     //Assignment를 DetailAssignmentResponse로 변환
     private DetailAssignmentResponse createDetailAssignmentResponse(Assignment assignment) {
+
         return DetailAssignmentResponse.builder()
                 .assignmentId(assignment.getAssignId())
                 .title(assignment.getTitle())
@@ -207,6 +272,7 @@ public class AssignmentService {
 
     //Assignment를 AssignmentResponse로 변환
     private AssignmentResponse createResponse(Assignment assignment) {
+
         return AssignmentResponse.builder()
                 .assignmentId(assignment.getAssignId())
                 .title(assignment.getTitle())
@@ -214,6 +280,16 @@ public class AssignmentService {
                 .startDate(assignment.getStartDate())
                 .endDate(assignment.getEndDate())
                 .createdAt(assignment.getCreatedAt())
+                .build();
+    }
+
+    private SubmissionResponse createSubmissionResponse(AssignmentSubmission assignmentSubmission) {
+
+        return SubmissionResponse.builder()
+                .submissionId(assignmentSubmission.getSubmissionId())
+                .content(assignmentSubmission.getContent())
+                .creatorName(assignmentSubmission.getSubmitter().getName())
+                .createdAt(assignmentSubmission.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -42,7 +42,8 @@ public enum ErrorCode {
 
     //스터디
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
-    UNAUTHORIZED_ROLE(HttpStatus.UNAUTHORIZED, "멘토만 과제를 관리할 수 있습니다."),
+    UNAUTHORIZED_MENTO_ROLE(HttpStatus.UNAUTHORIZED, "멘토만 과제를 관리할 수 있습니다."),
+    UNAUTHORIZED_MENTEE_ROLE(HttpStatus.UNAUTHORIZED, "멘티만 과제를 제출할 수 있습니다."),
     STUDY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스터디 멤버를 찾을 수 없습니다."),
 
     //과제

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -25,7 +25,8 @@ public enum ResponseMessage {
     ASSIGNMENT_CREATE_SUCCESS("과제 등록 성공"),
     ASSIGNMENT_DELETE_SUCCESS("과제 삭제 성공"),
     ASSIGNMENT_UPDATE_SUCCESS("과제 수정 성공"),
-    ASSIGNMENT_SUCCESS("과제 조회 성공")
+    ASSIGNMENT_SUCCESS("과제 조회 성공"),
+    ASSIGNMENT_SUBMIT_SUCCESS("과제 제출 성공")
     ;
 
     private final String message;


### PR DESCRIPTION
### 과제 제출하기 (멘티용)

해당 스터디의 멘티가 과제를 제출하는 기능을 추가했습니다.

조금 마음에 걸리는 건
```java
@Data
public class SubmissionDto {

    @NotBlank(message = "과제 내용을 입력해주세요!")
    private String content;
}
```
Dto로 제출하는 변수가 `content` 하나밖에 없다는 거?

### 그 외 수정사항 + 변경점

- createAssignment 에서의 Dto 변수들에 `@NotNull` 이나 `@NotBlank` 를 추가해 null을 방지했습니다.
- updateAssignment 의 Service 단에서 null이 아닌 경우에만 데이터를 변경하도록 수정했습니다.
- DTO -> Dto 로 변경했습니다.
- 코드 컨벤션에 맞게 메소드 내부 첫번째 줄은 공백줄 규칙을 적용했습니다.
- 과제 댓글 처리용 Entity를 하나 만들었습니다.

과제 댓글 처리용 Entity의 경우, 답글 기능까지 고려해서 만드려고 하다가 방법이 구체화되지 않아 일단 주석처리했습니다.
이 경우, 아까 백엔드 회의할 때 물어봤어야 했는데 그놈의 잠이 웬수;;
다음 주 회의때 한번 얘기하겠습니다.

---

**테스트**

과제 제출 실패 (멘토라서)
<img width="970" height="568" alt="image" src="https://github.com/user-attachments/assets/b79f43ad-ad7d-4e9c-a7b0-ff1eb9d6373a" />

과제 제출 성공
<img width="656" height="515" alt="image" src="https://github.com/user-attachments/assets/95a12e31-ccae-42bc-b735-3a0aa08951e3" />

과제가 없는 경우
<img width="633" height="468" alt="image" src="https://github.com/user-attachments/assets/e80c852f-cab3-4952-af37-90d5d80ca914" />

스터디가 없는 경우
<img width="660" height="458" alt="image" src="https://github.com/user-attachments/assets/ec2598e9-f172-4aa5-94fd-eb2a1b49c0fb" />

---

그 외 수정사항, 피드백, 코멘트, 오늘의 TMI 뭐든 좋아요 남겨주세용
<img width="259" height="194" alt="image" src="https://github.com/user-attachments/assets/1a8bac0b-d743-43fd-89a9-64336bddf307" />

TMI: 이번 시즌 롤체 개꿀잼임 님들도 하셈

