### PR TITLE
Feat/delete announcement 공지사항 삭제 

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/AnnouncementController.java
+++ b/src/main/java/com/mjsec/lms/controller/AnnouncementController.java
@@ -7,7 +7,6 @@ import com.mjsec.lms.dto.SuccessResponse;
 import com.mjsec.lms.mapper.AnnouncementMapper;
 import com.mjsec.lms.service.AnnouncementService;
 import com.mjsec.lms.type.ResponseMessage;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -82,6 +81,19 @@ public class AnnouncementController {
 
         return ResponseEntity.ok(
                 SuccessResponse.of(ResponseMessage.UPDATE_ANNOUNCEMENT_SUCCESS,updated)
+        );
+    }
+
+    @DeleteMapping("/announcements/{announcementId}")
+    public ResponseEntity<SuccessResponse> deleteAnnouncement(
+            @PathVariable Long announcementId,
+            Authentication authentication){
+
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+        announcementService.deleteAnnouncement(announcementId, currentUserStudentNumber);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(ResponseMessage.DELETE_ANNOUNCEMENT_SUCCESS)
         );
     }
 

--- a/src/main/java/com/mjsec/lms/service/AnnouncementService.java
+++ b/src/main/java/com/mjsec/lms/service/AnnouncementService.java
@@ -9,7 +9,9 @@ import com.mjsec.lms.mapper.AnnouncementMapper;
 import com.mjsec.lms.repository.*;
 import com.mjsec.lms.type.ErrorCode;
 import com.mjsec.lms.type.UserRole;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -100,12 +102,46 @@ public class AnnouncementService {
             throw new RestApiException(ErrorCode.UNAUTHORIZED_ROLE);
         }
 
-        announcement.setTitle(dto.getTitle());
-        announcement.setContent(dto.getContent());
-        announcement.setType(dto.getType());
+        //데이터가 null이 아닌 경우에만 업데이트
+        if (dto.getTitle() != null) {
+            announcement.setTitle(dto.getTitle());
+        }
+
+        if (dto.getContent() != null) {
+            announcement.setContent(dto.getContent());
+        }
+
+        if (dto.getType() != null) {
+            announcement.setType(dto.getType());
+        }
+
         announcement.setUpdatedAt(LocalDateTime.now());
+
         Announcement saved = announcementRepository.save(announcement);
         return AnnouncementMapper.toDto(saved);
+    }
+
+    //공지사항 삭제하기
+    @Transactional
+    public void  deleteAnnouncement(Long announcementId, Long currentUserStudentNumber) {
+
+        //유저 권한 + 관리자 권한 확인
+        User user = validateUser(currentUserStudentNumber);
+        if (user.getRole() != UserRole.ROLE_ADMIN) {
+            throw new RestApiException(ErrorCode.UNAUTHORIZED_ROLE);
+        }
+
+        // 조회할 수 있는 공지사항인지 확인
+        Announcement announcement = announcementRepository.findById(announcementId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.ANNOUNCEMENT_NOT_FOUND)
+                );
+
+        //작성자 본인이 맞는지 확인
+        if (!announcement.getCreator().getUserId().equals(user.getUserId())) {
+            throw new RestApiException(ErrorCode.UNAUTHORIZED_ROLE);
+        }
+
+        announcementRepository.delete(announcement);
     }
 
     private User validateUser(Long studentNumber) {

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -29,6 +29,8 @@ public enum ResponseMessage {
     POST_ANNOUNCEMENT_SUCCESS("공지사항 등록 성공"),
     GET_ANNOUNCEMENT_SUCCESS("전체 공지사항 목록 반환 성공"),
     DETAIL_ANNOUNCEMENT_SUCCESS("공지사항 상제 조회 성공"),
-    UPDATE_ANNOUNCEMENT_SUCCESS("공지사항 수정 성공");
+    UPDATE_ANNOUNCEMENT_SUCCESS("공지사항 수정 성공"),
+    DELETE_ANNOUNCEMENT_SUCCESS("공지사항 삭제 성공");
+
     private final String message;
 }


### PR DESCRIPTION
공지사항 삭제 기능을 구현했습니다!

📌공지사항 수정과 비슷한 로직으로 만들었습니다. 
유저+ 관리자 권한을 확인하고
공지사항이 있는지 확인하고
해당 공지사항을 작성한 유저가 접근하는 것인지 확인합니다.

<img width="768" height="781" alt="스크린샷 2025-08-10 오후 7 01 23" src="https://github.com/user-attachments/assets/a7d2dddc-b303-44a5-af52-c666feeb537d" />

전체 공지사항 목록입니다.

<img width="768" height="781" alt="스크린샷 2025-08-10 오후 7 06 37" src="https://github.com/user-attachments/assets/5cfb0d09-77f2-473d-b20d-ad69517f3662" />

공지사항을 성공적으로 삭제했을 때의 모습입니다.

<img width="768" height="781" alt="스크린샷 2025-08-10 오후 7 06 52" src="https://github.com/user-attachments/assets/c869c2da-854d-4026-9e4b-48d2ab34d65b" />

1,2번 공지사항을 지운 후 전체 공지사항 목록을 반환했습니다. 

<img width="1440" height="215" alt="스크린샷 2025-08-10 오후 7 18 10" src="https://github.com/user-attachments/assets/2d4b1b7f-0a26-4d03-938e-82a27dcb3016" />

DB에서도 사라진 모습


📌에러처리는 공지사항 수정 로직과 같은 방법으로 처리했습니다. 

API에 나와있는 내용을 바탕으로 전부 구성했습니다.
이제 에러처리 많이 다듬어야지,,,,,
피드백 해주시면 수정하겠습니다!

