### PR TITLE
Feat: 과제 제출 수정/삭제/조회 기능 + 과제 피드백과 과제란 댓글 등

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/AssignmentController.java
+++ b/src/main/java/com/mjsec/lms/controller/AssignmentController.java
@@ -4,11 +4,11 @@ package com.mjsec.lms.controller;
 import com.mjsec.lms.dto.*;
 import com.mjsec.lms.service.AssignmentService;
 import com.mjsec.lms.type.ResponseMessage;
+import com.mjsec.lms.util.IpUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -47,12 +47,12 @@ public class AssignmentController {
     @GetMapping("/{groupId}/assignments")
     public ResponseEntity<SuccessResponse<List<AssignmentResponse>>> getAssignments(
             @PathVariable Long groupId,
-            Authentication authentication){
+            Authentication authentication) {
 
         // JwtFilter에서 설정한 studentNumber를 가져옴
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();
 
-        List<AssignmentResponse> assignmentResponseList = assignmentService.getAssignment(groupId,currentUserStudentNumber);
+        List<AssignmentResponse> assignmentResponseList = assignmentService.getAssignment(groupId, currentUserStudentNumber);
 
         return ResponseEntity.ok(
                 SuccessResponse.of(
@@ -67,12 +67,12 @@ public class AssignmentController {
     public ResponseEntity<SuccessResponse<DetailAssignmentResponse>> getDetailedAssignment(
             @PathVariable Long groupId,
             @PathVariable Long assignId,
-            Authentication authentication){
+            Authentication authentication) {
 
         // JwtFilter에서 설정한 studentNumber를 가져옴
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();
 
-        DetailAssignmentResponse detailAssignmentResponse = assignmentService.getDetailAssignment(groupId,assignId,currentUserStudentNumber);
+        DetailAssignmentResponse detailAssignmentResponse = assignmentService.getDetailAssignment(groupId, assignId, currentUserStudentNumber);
 
         return ResponseEntity.ok(
                 SuccessResponse.of(
@@ -88,7 +88,7 @@ public class AssignmentController {
             @PathVariable Long groupId,
             @PathVariable Long assignId,
             @RequestBody AssignmentDto dto,
-            Authentication authentication){
+            Authentication authentication) {
 
         // JwtFilter에서 설정한 studentNumber를 가져옴
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();
@@ -108,12 +108,12 @@ public class AssignmentController {
     public ResponseEntity<SuccessResponse<Void>> deleteAssignment(
             @PathVariable Long groupId,
             @PathVariable Long assignId,
-            Authentication authentication){
+            Authentication authentication) {
 
         // JwtFilter에서 설정한 studentNumber를 가져옴
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();
 
-        assignmentService.deleteAssignment(groupId,assignId,currentUserStudentNumber);
+        assignmentService.deleteAssignment(groupId, assignId, currentUserStudentNumber);
 
         return ResponseEntity.ok(
                 SuccessResponse.of(
@@ -129,15 +129,15 @@ public class AssignmentController {
             @PathVariable Long groupId,
             @PathVariable Long assignId,
             Authentication authentication,
-            HttpServletRequest request){
+            HttpServletRequest request) {
 
         // JwtFilter에서 설정한 studentNumber를 가져옴
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();
 
         //클라이언트 IP 뽑아내기
-        String clientIpAddr = extractClientIp(request);
+        String clientIpAddr = IpUtil.getClientIp(request);
 
-        SubmissionResponse submissionResponse = assignmentService.submitAssignment(groupId,assignId,currentUserStudentNumber,dto,clientIpAddr);
+        SubmissionResponse submissionResponse = assignmentService.submitAssignment(groupId, assignId, currentUserStudentNumber, dto, clientIpAddr);
 
         return ResponseEntity.ok(
                 SuccessResponse.of(
@@ -147,51 +147,136 @@ public class AssignmentController {
         );
     }
 
-    //클라이언트 IP 뽑아내기
-    private String extractClientIp(HttpServletRequest request) {
+    /**
+     * 전체 과제 제출 리스트 확인 가능
+     */
+    @GetMapping("/{groupId}/assign-submit/{assignId}/submissions")
+    public ResponseEntity<SuccessResponse<List<SubmissionResponse>>> getSubmissionList(
+            @PathVariable Long groupId,
+            @PathVariable Long assignId,
+            Authentication authentication
+    ) {
 
-        String clientIp = null;
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
 
-        // X-Forwarded-For 헤더 확인
-        clientIp = request.getHeader("X-Forwarded-For");
-        if (StringUtils.hasText(clientIp) && !isUnknownIp(clientIp)) {
-            return clientIp.split(",")[0].trim();
-        }
+        List<SubmissionResponse> submissionResponseList = assignmentService.getSubmissionList(groupId, assignId, currentUserStudentNumber);
 
-        // Proxy-Client-IP 헤더 확인
-        clientIp = request.getHeader("Proxy-Client-IP");
-        if (StringUtils.hasText(clientIp) && !isUnknownIp(clientIp)) {
-            return clientIp;
-        }
-
-        // WL-Proxy-Client-IP 헤더 확인
-        clientIp = request.getHeader("WL-Proxy-Client-IP");
-        if (StringUtils.hasText(clientIp) && !isUnknownIp(clientIp)) {
-            return clientIp;
-        }
-
-        // HTTP_CLIENT_IP 헤더 확인
-        clientIp = request.getHeader("HTTP_CLIENT_IP");
-        if (StringUtils.hasText(clientIp) && !isUnknownIp(clientIp)) {
-            return clientIp;
-        }
-
-        // HTTP_X_FORWARDED_FOR 헤더 확인
-        clientIp = request.getHeader("HTTP_X_FORWARDED_FOR");
-        if (StringUtils.hasText(clientIp) && !isUnknownIp(clientIp)) {
-            return clientIp;
-        }
-
-        // 기본적으로 getRemoteAddr() 사용
-        return request.getRemoteAddr();
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.ASSIGNMENT_SUBMIT_CHECK_SUCCESS,
+                        submissionResponseList
+                )
+        );
     }
 
-    //알 수 없는 IP인지 확인하기
-    private boolean isUnknownIp(String ip) {
+    /**
+    * 유저별 과제 제출 확인하기 (멘토/멘티 둘 다 가능)
+     * 멘티 (자기 자신 과제만 조회 가능)
+     * 멘토 (나머지도 다 가능)
+     */
+    @GetMapping("/{groupId}/assign-submit/{assignId}/submissions/{submitId}")
+    public ResponseEntity<SuccessResponse<DetailSubmissionResponse>> getUserDetailedSubmission(
+            @PathVariable Long groupId,
+            @PathVariable Long assignId,
+            @PathVariable Long submitId,
+            Authentication authentication) {
 
-        return "unknown".equalsIgnoreCase(ip) ||
-                "0:0:0:0:0:0:0:1".equals(ip) ||
-                "127.0.0.1".equals(ip);
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        DetailSubmissionResponse detailSubmissionResponse = assignmentService.getDetailedSubmission(groupId, assignId, submitId, currentUserStudentNumber);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.ASSIGNMENT_SUBMIT_CHECK_SUCCESS,
+                        detailSubmissionResponse
+                )
+        );
+    }
+
+    //과제 제출 수정하기
+    @PutMapping("/{groupId}/assign-submit/{assignId}/submissions/{submitId}")
+    public ResponseEntity<SuccessResponse<DetailSubmissionResponse>> updateSubmission(
+            @PathVariable Long groupId,
+            @PathVariable Long assignId,
+            @PathVariable Long submitId,
+            @RequestBody SubmissionDto dto,
+            Authentication authentication){
+
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        DetailSubmissionResponse detailSubmissionResponse = assignmentService.updateAssignmentSubmission(groupId, assignId, submitId, currentUserStudentNumber, dto);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.ASSIGNMENT_SUBMIT_UPDATE_SUCCESS,
+                        detailSubmissionResponse
+                )
+        );
+    }
+
+    //과제 제출 삭제하기
+    @DeleteMapping("/{groupId}/assign-submit/{assignId}/submissions/{submitId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteSubmission(
+            @PathVariable Long groupId,
+            @PathVariable Long assignId,
+            @PathVariable Long submitId,
+            Authentication authentication){
+
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        assignmentService.deleteAssignmentSubmission(groupId, assignId, submitId, currentUserStudentNumber);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.ASSIGNMENT_SUBMIT_DELETE_SUCCESS
+                )
+        );
+    }
+
+    //과제 제출 피드백 남기기
+    @PostMapping("/{groupId}/assign-submit/{assignId}/submissions/{submitId}/feedback")
+    public ResponseEntity<SuccessResponse<Void>> leaveFeedback(
+            @PathVariable Long groupId,
+            @PathVariable Long assignId,
+            @PathVariable Long submitId,
+            @RequestBody SubmissionFeedbackDto dto,
+            Authentication authentication){
+
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        assignmentService.leaveFeedback(groupId, assignId, submitId, currentUserStudentNumber, dto);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.LEAVE_FEEDBACK_SUCCESS
+                )
+        );
+    }
+
+    //댓글 생성하기
+    @PostMapping("/{groupId}/assignments/{assignId}/create-comment")
+    public ResponseEntity<SuccessResponse<AssignmentCommentResponse>> createAssignmentComment(
+            @PathVariable Long groupId,
+            @PathVariable Long assignId,
+            @RequestBody AssignmentCommentDto dto,
+            Authentication authentication){
+
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        AssignmentCommentResponse assignmentComment = assignmentService.createAssignmentComment(groupId, assignId, currentUserStudentNumber, dto);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.COMMENT_CREATE_SUCCESS,
+                        assignmentComment
+                )
+        );
     }
 
 }

--- a/src/main/java/com/mjsec/lms/dto/AssignmentCommentDto.java
+++ b/src/main/java/com/mjsec/lms/dto/AssignmentCommentDto.java
@@ -1,0 +1,17 @@
+package com.mjsec.lms.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssignmentCommentDto {
+
+    @NotBlank(message = "댓글을 입력해주세요!")
+    private String content;
+}

--- a/src/main/java/com/mjsec/lms/dto/AssignmentCommentResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/AssignmentCommentResponse.java
@@ -1,0 +1,21 @@
+package com.mjsec.lms.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class AssignmentCommentResponse {
+
+    private Long commentId;
+
+    private Long assignmentId;
+
+    private String content;
+
+    private String creatorName;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/mjsec/lms/dto/DetailAssignmentResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/DetailAssignmentResponse.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Builder
@@ -20,6 +21,10 @@ public class DetailAssignmentResponse {
     private LocalDateTime endDate;
 
     private String creatorName;
+
+    private int commentCount;
+
+    private List<AssignmentCommentResponse> commentList;
 
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/mjsec/lms/dto/DetailSubmissionResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/DetailSubmissionResponse.java
@@ -1,0 +1,25 @@
+package com.mjsec.lms.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class DetailSubmissionResponse {
+
+    private Long submissionId;
+
+    private String content;
+
+    private String password;
+
+    private String creatorName;
+
+    private String feedback;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/mjsec/lms/dto/SubmissionDto.java
+++ b/src/main/java/com/mjsec/lms/dto/SubmissionDto.java
@@ -1,13 +1,15 @@
 package com.mjsec.lms.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Data;
 
 //과제 제출 Dto
 @Data
+@Builder
 public class SubmissionDto {
 
-    @NotBlank(message = "과제 내용을 입력해주세요!")
+    @NotBlank(message = "과제 링크을 입력해주세요!")
     private String content;
 
     private String password;

--- a/src/main/java/com/mjsec/lms/dto/SubmissionFeedbackDto.java
+++ b/src/main/java/com/mjsec/lms/dto/SubmissionFeedbackDto.java
@@ -1,0 +1,16 @@
+package com.mjsec.lms.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubmissionFeedbackDto {
+
+    private String feedback;
+    
+}

--- a/src/main/java/com/mjsec/lms/repository/AssignmentCommentRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/AssignmentCommentRepository.java
@@ -1,0 +1,14 @@
+package com.mjsec.lms.repository;
+
+import com.mjsec.lms.domain.AssignmentComment;
+import com.mjsec.lms.dto.AssignmentCommentDto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AssignmentCommentRepository extends JpaRepository<AssignmentComment, Long> {
+
+    public List<AssignmentComment> findAllByAssignmentAssignId(Long assignId);
+}

--- a/src/main/java/com/mjsec/lms/repository/SubmissionRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/SubmissionRepository.java
@@ -4,8 +4,15 @@ import com.mjsec.lms.domain.AssignmentSubmission;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface SubmissionRepository extends JpaRepository<AssignmentSubmission, Long> {
 
     boolean existsBySubmitterUserIdAndAssignmentAssignId(Long submitterUserId, Long assignmentAssignId);
+
+    Optional<AssignmentSubmission> findBySubmitterUserIdAndAssignmentAssignId(Long submitterUserId, Long assignmentAssignId);
+
+    List<AssignmentSubmission> findAssignmentSubmissionsByAssignmentAssignId(Long assignmentAssignId);
 }

--- a/src/main/java/com/mjsec/lms/service/AssignmentService.java
+++ b/src/main/java/com/mjsec/lms/service/AssignmentService.java
@@ -1,9 +1,6 @@
 package com.mjsec.lms.service;
 
-import com.mjsec.lms.domain.Assignment;
-import com.mjsec.lms.domain.AssignmentSubmission;
-import com.mjsec.lms.domain.StudyGroup;
-import com.mjsec.lms.domain.User;
+import com.mjsec.lms.domain.*;
 import com.mjsec.lms.dto.*;
 import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.repository.*;
@@ -29,6 +26,7 @@ public class AssignmentService {
     private final StudyGroupRepository studyGroupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final SubmissionRepository submissionRepository;
+    private final AssignmentCommentRepository assignmentCommentRepository;
 
     private static final String[] ALLOWED_DOMAINS =
             {"velog.io", "tistory.com", "blog.naver.com"};
@@ -39,13 +37,15 @@ public class AssignmentService {
                              UserRepository userRepository,
                              StudyGroupRepository studyGroupRepository,
                              GroupMemberRepository groupMemberRepository,
-                             SubmissionRepository submissionRepository) {
+                             SubmissionRepository submissionRepository,
+                             AssignmentCommentRepository assignmentCommentRepository) {
 
         this.assignmentRepository = assignmentRepository;
         this.userRepository = userRepository;
         this.studyGroupRepository = studyGroupRepository;
         this.groupMemberRepository = groupMemberRepository;
         this.submissionRepository = submissionRepository;
+        this.assignmentCommentRepository = assignmentCommentRepository;
     }
 
     // 과제 등록하기 (멘토만 가능함.)
@@ -56,7 +56,7 @@ public class AssignmentService {
 
         User user = validateUser(currentUserStudentNumber);
         StudyGroup studyGroup = validateStudyGroup(groupId);
-        validateMentorRole(user.getUserId(), groupId);
+        validateMentoRole(user.getUserId(), groupId);
 
         log.info("User {} is confirmed as MENTO of StudyGroup: {}", user.getUserId(), studyGroup.getName());
 
@@ -121,7 +121,7 @@ public class AssignmentService {
 
         User user = validateUser(currentUserStudentNumber);
         validateStudyGroup(groupId);
-        validateMentorRole(user.getUserId(), groupId);
+        validateMentoRole(user.getUserId(), groupId);
         Assignment assignment = validateAssignment(assignmentId);
 
         log.info("Found assignment: {}", assignment);
@@ -138,7 +138,7 @@ public class AssignmentService {
 
         User user = validateUser(currentUserStudentNumber);
         validateStudyGroup(groupId);
-        validateMentorRole(user.getUserId(), groupId);
+        validateMentoRole(user.getUserId(), groupId);
         Assignment assignment = validateAssignment(assignmentId);
 
         log.info("Found assignment: {}", assignment);
@@ -147,7 +147,7 @@ public class AssignmentService {
         log.info("Assignment deleted successfully: {}", assignment);
     }
 
-    //과제 제출하기
+    //과제 제출하기 (멘티만)
     @Transactional
     public SubmissionResponse submitAssignment(Long groupId, Long assignmentId, Long currentUserStudentNumber, SubmissionDto dto, String ipAddress) {
 
@@ -180,10 +180,156 @@ public class AssignmentService {
         return createSubmissionResponse(assignmentSubmission);
     }
 
+    //과제 제출 리스트 확인하기 (멘토/멘티)
+    @Transactional(readOnly = true)
+    public List<SubmissionResponse> getSubmissionList(Long groupId, Long assignmentId, Long currentUserStudentNumber) {
+
+        log.info("getSubmissionList called");
+
+        User user = validateUser(currentUserStudentNumber);
+        StudyGroup studyGroup = validateStudyGroup(groupId);
+        validateGroupMembership(user, studyGroup);
+        Assignment assignment = validateAssignment(assignmentId);
+
+        List<SubmissionResponse> submissionResponses = new ArrayList<>();
+        List<AssignmentSubmission> assignmentSubmissionList = submissionRepository.findAssignmentSubmissionsByAssignmentAssignId(assignment.getAssignId());
+        for (AssignmentSubmission assignmentSubmission : assignmentSubmissionList) {
+            submissionResponses.add(createSubmissionResponse(assignmentSubmission));
+        }
+
+        return submissionResponses;
+    }
+
+    /**
+     * 유저별 과제 제출 확인하기 (멘토/멘티 둘 다 가능)
+     * 멘티 (자기 자신 과제만 조회 가능)
+     * 멘토 (나머지도 다 가능)
+     */
+    @Transactional(readOnly = true)
+    public DetailSubmissionResponse getDetailedSubmission(Long groupId, Long assignmentId,Long submitId, Long currentUserStudentNumber) {
+        
+        log.info("getUserDetailedSubmission called");
+
+        User user = validateUser(currentUserStudentNumber);
+        validateStudyGroup(groupId);
+        validateAssignment(assignmentId);
+        AssignmentSubmission assignmentSubmission = validateSubmission(submitId);
+        GroupMemberRole role = validateUserRole(user.getUserId(), groupId);
+
+        if (!assignmentSubmission.getAssignment().getAssignId().equals(assignmentId)) {
+            throw new RestApiException(ErrorCode.SUBMISSION_ASSIGNMENT_MISMATCH);
+        }
+
+        if(role == GroupMemberRole.MENTEE) {
+            if (!assignmentSubmission.getSubmitter().getUserId().equals(user.getUserId())) {
+                log.warn("User {} attempted to access submission {} which is not theirs",
+                        user.getUserId(), submitId);
+                throw new RestApiException(ErrorCode.UNAUTHORIZED_ACCESS_SUBMISSION);
+            }
+        }
+        else if(role == GroupMemberRole.MENTO) {
+            log.info("Mentor {} accessing submission {}", user.getUserId(), submitId);
+        }
+
+        return createDetailSubmissionResponse(assignmentSubmission);
+    }
+
+    @Transactional
+    public DetailSubmissionResponse updateAssignmentSubmission(Long groupId, Long assignmentId, Long submitId, Long currentUserStudentNumber,SubmissionDto dto) {
+
+        log.info("updateAssignmentSubmission called");
+
+        User user = validateUser(currentUserStudentNumber);
+        validateStudyGroup(groupId);
+        validateAssignment(assignmentId);
+        validateMenteeRole(user.getUserId(), groupId);
+        AssignmentSubmission assignmentSubmission = validateSubmission(submitId);
+        validateAssignmentIdInAssignmentSubmission(assignmentId, assignmentSubmission);
+        validateSubmissionOwnership(assignmentSubmission, user.getUserId());
+
+        return updateSubmitData(assignmentSubmission, dto);
+    }
+
+    @Transactional
+    public void deleteAssignmentSubmission(Long groupId, Long assignmentId, Long submitId, Long currentUserStudentNumber) {
+
+        log.info("deleteAssignmentSubmission called");
+
+        User user = validateUser(currentUserStudentNumber);
+        validateStudyGroup(groupId);
+        validateAssignment(assignmentId);
+        validateMenteeRole(user.getUserId(), groupId);
+        AssignmentSubmission assignmentSubmission = validateSubmission(submitId);
+        validateAssignmentIdInAssignmentSubmission(assignmentId, assignmentSubmission);
+        validateSubmissionOwnership(assignmentSubmission, user.getUserId());
+
+        submissionRepository.delete(assignmentSubmission);
+
+        log.info("Assignment submission deleted successfully: {}", assignmentSubmission);
+    }
+
+    //멘토가 과제 피드백 남기기
+    @Transactional
+    public void leaveFeedback(Long groupId, Long assignmentId, Long submitId, Long currentUserStudentNumber, SubmissionFeedbackDto dto) {
+
+        log.info("leaveFeedback called");
+
+        User user = validateUser(currentUserStudentNumber);
+        validateStudyGroup(groupId);
+        validateAssignment(assignmentId);
+        validateMentoRole(user.getUserId(), groupId);
+        AssignmentSubmission assignmentSubmission = validateSubmission(submitId);
+
+        leaveFeedbackData(assignmentSubmission, dto);
+    }
+
+    //과제 댓글 생성
+    @Transactional
+    public AssignmentCommentResponse createAssignmentComment(Long groupId, Long assignmentId, Long currentUserStudentNumber, AssignmentCommentDto dto) {
+
+        log.info("createAssignmentComment call");
+
+        User user = validateUser(currentUserStudentNumber);
+        StudyGroup studyGroup = validateStudyGroup(groupId);
+        Assignment assignment = validateAssignment(assignmentId);
+        validateGroupMembership(user,studyGroup);
+
+        AssignmentComment assignmentComment = AssignmentComment.builder()
+                .assignment(assignment)
+                .author(user)
+                .content(dto.getContent())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        assignmentCommentRepository.save(assignmentComment);
+
+        return createAssignmentCommentResponse(assignmentComment);
+    }
+
     /**
      * === 검증 메서드들 ===
      */
 
+    // 제출물이 해당 과제에 속하는지 검증
+    private void validateAssignmentIdInAssignmentSubmission(Long assignmentId, AssignmentSubmission assignmentSubmission) {
+
+        if(!assignmentSubmission.getAssignment().getAssignId().equals(assignmentId)) {
+            log.warn("Assignment id mismatch between assignment and assignment submission");
+            throw new RestApiException(ErrorCode.SUBMISSION_ASSIGNMENT_MISMATCH);
+        }
+    }
+
+    //제출된 과제와 제출한 유저가 동일인물인지 검증
+    private void validateSubmissionOwnership(AssignmentSubmission assignmentSubmission, Long userId){
+
+        if(!assignmentSubmission.getSubmitter().getUserId().equals(userId)) {
+            log.warn("User {} attempted to update submission {} which is not theirs",
+                    userId, assignmentSubmission.getSubmitter().getUserId());
+            throw new RestApiException(ErrorCode.UNAUTHORIZED_ACCESS_SUBMISSION);
+        }
+    }
+
+    //과제 제출 내용에 문제가 없는지 검증
     private void validateSubmissionContent(String content) {
 
         if(content == null || content.trim().isEmpty()) {
@@ -296,6 +442,7 @@ public class AssignmentService {
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_NOT_FOUND));
     }
 
+    //사용자가 해당 스터디 그룹의 멘티인지 확인
     private void validateMenteeRole(Long userId, Long groupId) {
 
         GroupMemberRole userRole = groupMemberRepository.findRoleByUserIdAndStudyId(userId, groupId)
@@ -308,7 +455,7 @@ public class AssignmentService {
     }
 
     //사용자가 해당 스터디 그룹의 멘토인지 확인
-    private void validateMentorRole(Long userId, Long groupId) {
+    private void validateMentoRole(Long userId, Long groupId) {
 
         GroupMemberRole userRole = groupMemberRepository.findRoleByUserIdAndStudyId(userId, groupId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
@@ -317,6 +464,13 @@ public class AssignmentService {
             log.warn("User {} does not have MENTO role in StudyGroup {}. Current role: {}", userId, groupId, userRole);
             throw new RestApiException(ErrorCode.UNAUTHORIZED_MENTO_ROLE);
         }
+    }
+
+    //사용자가 멘토인지 멘티인지 확인하기
+    private GroupMemberRole validateUserRole(Long userId, Long groupId) {
+
+        return groupMemberRepository.findRoleByUserIdAndStudyId(userId, groupId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
     }
 
     //사용자가 해당 스터디 그룹의 멤버인지 확인
@@ -343,6 +497,13 @@ public class AssignmentService {
             log.warn("User {} attempted duplicate submission for assignment {}", userId, assignmentId);
             throw new RestApiException(ErrorCode.DUPLICATE_SUBMISSION);
         }
+    }
+
+    //제출한 과제가 존재하는지 검증
+    private AssignmentSubmission validateSubmission(Long submitId) {
+
+        return submissionRepository.findById(submitId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.SUBMISSION_NOT_FOUND));
     }
 
     /**
@@ -378,12 +539,36 @@ public class AssignmentService {
         log.info("Assignment updated successfully: {}", assignment);
     }
 
+    //제출한 과제 내용을 업데이트
+    private DetailSubmissionResponse updateSubmitData(AssignmentSubmission assignmentSubmission, SubmissionDto dto) {
+
+        if(dto.getContent() != null && !dto.getContent().trim().isEmpty()){
+            validateSubmissionContent(dto.getContent());
+            assignmentSubmission.setContent(dto.getContent());
+        }
+
+        if(dto.getPassword() != null && !dto.getPassword().trim().isEmpty()){
+            assignmentSubmission.setPassword(dto.getPassword());
+        }
+
+        assignmentSubmission.setUpdatedAt(LocalDateTime.now());
+        submissionRepository.save(assignmentSubmission);
+
+        return createDetailSubmissionResponse(assignmentSubmission);
+    }
+
     /**
      * === DTO 변환 메서드들 ===
      */
 
     //Assignment를 DetailAssignmentResponse로 변환
     private DetailAssignmentResponse createDetailAssignmentResponse(Assignment assignment) {
+        List<AssignmentComment> assignmentCommentList = assignmentCommentRepository.findAllByAssignmentAssignId(assignment.getAssignId());
+        List<AssignmentCommentResponse> commentList = new ArrayList<>();
+
+        for(AssignmentComment comment : assignmentCommentList) {
+            commentList.add(createAssignmentCommentResponse(comment));
+        }
 
         return DetailAssignmentResponse.builder()
                 .assignmentId(assignment.getAssignId())
@@ -393,6 +578,8 @@ public class AssignmentService {
                 .endDate(assignment.getEndDate())
                 .creatorName(assignment.getCreator().getName())
                 .createdAt(assignment.getCreatedAt())
+                .commentCount(assignmentCommentList.size())
+                .commentList(commentList)
                 .updatedAt(assignment.getUpdatedAt())
                 .build();
     }
@@ -418,6 +605,45 @@ public class AssignmentService {
                 .content(assignmentSubmission.getContent())
                 .creatorName(assignmentSubmission.getSubmitter().getName())
                 .createdAt(assignmentSubmission.getCreatedAt())
+                .build();
+    }
+
+    //과제 제출 (디테일) 반환용
+    private DetailSubmissionResponse createDetailSubmissionResponse(AssignmentSubmission assignmentSubmission) {
+
+        return DetailSubmissionResponse.builder()
+                .submissionId(assignmentSubmission.getSubmissionId())
+                .content(assignmentSubmission.getContent())
+                .creatorName(assignmentSubmission.getSubmitter().getName())
+                .createdAt(assignmentSubmission.getCreatedAt())
+                .updatedAt(assignmentSubmission.getUpdatedAt())
+                .password(assignmentSubmission.getPassword())
+                .feedback(assignmentSubmission.getFeedback())
+                .build();
+    }
+
+    private void leaveFeedbackData(AssignmentSubmission submission, SubmissionFeedbackDto dto) {
+
+        if(dto.getFeedback() != null && !dto.getFeedback().trim().isEmpty()){
+            submission.setFeedback(dto.getFeedback());
+        }
+        else{
+            submission.setFeedback(null);
+        }
+
+        submission.setUpdatedAt(LocalDateTime.now());
+
+        submissionRepository.save(submission);
+    }
+
+    private AssignmentCommentResponse createAssignmentCommentResponse(AssignmentComment assignmentComment) {
+
+        return AssignmentCommentResponse.builder()
+                .commentId(assignmentComment.getCommentId())
+                .content(assignmentComment.getContent())
+                .assignmentId(assignmentComment.getAssignment().getAssignId())
+                .creatorName(assignmentComment.getAuthor().getName())
+                .createdAt(assignmentComment.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -48,11 +48,19 @@ public enum ErrorCode {
 
     //과제
     ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "과제를 찾을 수 없습니다."),
-    SUBMISSION_CONTENT_REQUIRED(HttpStatus.NOT_FOUND, "제출 내용을 찾을 수 없습니다."),
+    SUBMISSION_CONTENT_REQUIRED(HttpStatus.NOT_FOUND, "과제 링크를 찾을 수 없습니다."),
     UNAUTHORIZED_DOMAIN(HttpStatus.UNAUTHORIZED, "허용되지 않은 도메인입니다."),
     INVALID_URL_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 URL입니다."),
     WARNING_CONTENT(HttpStatus.BAD_REQUEST, "허용되지 않은 내용입니다."),
     DUPLICATE_SUBMISSION(HttpStatus.BAD_REQUEST, "중복된 과제 제출입니다."),
+    SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "과제 제출 내역을 찾을 수 없습니다."),
+    UNAUTHORIZED_ACCESS_SUBMISSION(HttpStatus.UNAUTHORIZED, "과제 제출 조회 권한이 없습니다."),
+    SUBMISSION_ASSIGNMENT_MISMATCH(HttpStatus.NOT_FOUND, "제출물이 해당 과제에 속하지 않습니다."),
+
+    //공지사항
+    ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다."),
+    ANNOUNCEMENT_UNAUTHORIZED_ROLE(HttpStatus.FORBIDDEN, "공지사항에 접근할 권한이 없습니다."),
+    ANNOUNCEMENT_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "공지 타입은 필수입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -26,7 +26,19 @@ public enum ResponseMessage {
     ASSIGNMENT_DELETE_SUCCESS("과제 삭제 성공"),
     ASSIGNMENT_UPDATE_SUCCESS("과제 수정 성공"),
     ASSIGNMENT_SUCCESS("과제 조회 성공"),
-    ASSIGNMENT_SUBMIT_SUCCESS("과제 제출 성공")
+    ASSIGNMENT_SUBMIT_SUCCESS("과제 제출 성공"),
+    ASSIGNMENT_SUBMIT_CHECK_SUCCESS("과제 제출 확인 성공"),
+    ASSIGNMENT_SUBMIT_UPDATE_SUCCESS("과제 제출 내용 수정 성공"),
+    ASSIGNMENT_SUBMIT_DELETE_SUCCESS("제출한 과제 삭제 성공"),
+    LEAVE_FEEDBACK_SUCCESS("과제 피드백 남기기 성공"),
+    COMMENT_CREATE_SUCCESS("댓글 생성 성공"),
+
+    // Announcement관련
+    POST_ANNOUNCEMENT_SUCCESS("공지사항 등록 성공"),
+    GET_ANNOUNCEMENT_SUCCESS("전체 공지사항 목록 반환 성공"),
+    DETAIL_ANNOUNCEMENT_SUCCESS("공지사항 상제 조회 성공"),
+    UPDATE_ANNOUNCEMENT_SUCCESS("공지사항 수정 성공"),
+    DELETE_ANNOUNCEMENT_SUCCESS("공지사항 삭제 성공")
     ;
 
     private final String message;

--- a/src/main/java/com/mjsec/lms/util/IpUtil.java
+++ b/src/main/java/com/mjsec/lms/util/IpUtil.java
@@ -1,0 +1,75 @@
+package com.mjsec.lms.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.util.StringUtils;
+
+//IP 주소 추출을 위한 유틸리티 클래스
+public class IpUtil {
+
+    private static final String[] IP_HEADERS = {
+            "X-Forwarded-For",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_X_FORWARDED_FOR"
+    };
+
+    private static final String[] UNKNOWN_IPS = {
+            "unknown",
+            "0:0:0:0:0:0:0:1",
+            "127.0.0.1"
+    };
+
+    //HttpServletRequest에서 클라이언트의 실제 IP 주소를 추출합니다.
+    public static String getClientIp(HttpServletRequest request) {
+        if (request == null) {
+            return null;
+        }
+
+        // 각 헤더를 순차적으로 확인
+        for (String header : IP_HEADERS) {
+            String clientIp = request.getHeader(header);
+            if (isValidIp(clientIp)) {
+                // X-Forwarded-For의 경우 여러 IP가 콤마로 구분될 수 있음
+                if ("X-Forwarded-For".equals(header) && clientIp.contains(",")) {
+                    return clientIp.split(",")[0].trim();
+                }
+                return clientIp;
+            }
+        }
+
+        // 모든 헤더에서 찾지 못한 경우 기본 방법 사용
+        return request.getRemoteAddr();
+    }
+
+    //IP 주소가 유효한지 확인
+    private static boolean isValidIp(String ip) {
+        return StringUtils.hasText(ip) && !isUnknownIp(ip);
+    }
+
+    //알 수 없는 IP인지 확인
+    private static boolean isUnknownIp(String ip) {
+        if (ip == null) {
+            return true;
+        }
+
+        for (String unknownIp : UNKNOWN_IPS) {
+            if (unknownIp.equalsIgnoreCase(ip)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    //IP 주소가 로컬인지 확인
+    public static boolean isLocalIp(String ip) {
+        return "127.0.0.1".equals(ip) ||
+                "0:0:0:0:0:0:0:1".equals(ip) ||
+                "localhost".equalsIgnoreCase(ip);
+    }
+
+    // 유틸리티 클래스이므로 인스턴스화 방지
+    private IpUtil() {
+        throw new IllegalStateException("Utility class");
+    }
+}


### PR DESCRIPTION
### 대규모 업데이트 두둥탁

이번 PR은 좀 긴데, 그만큼 여러 기능이 있습니다요

**추가된 기능**

- 과제 제출 확인 (멘토/멘티)
- <과제별 제출 목록 확인 (멘토/멘티)>
- 과제 제출 수정
- 과제 제출 삭제
- 과제 피드백 남기기
- 생성된 과제에 대해 댓글을 남길 수 있는 기능

**변경사항**

- 과제 상세 조회에서 반환하는 Dto가 댓글 개수, 댓글 리스트를 담도록 변경했습니다.
- 클라이언트 IP를 뽑는 로직을 Util 라는 폴더에 옮겼습니다.

---

### **테스트**

**과제 상세 조회 변경**

<img width="577" height="760" alt="image" src="https://github.com/user-attachments/assets/a10ceaa0-6928-47d0-8418-a7899d58bacc" />

보시듯 댓글 개수와 댓글 리스트가 생긴 것을 확인할 수 있습니다.

그래서 댓글을 달면

<img width="637" height="601" alt="image" src="https://github.com/user-attachments/assets/91b91d79-8168-4859-8ae2-c8f0c1b9f5d6" />

이런 식으로 과제 상세 조회에서 댓글이 생깁니다.

<img width="680" height="886" alt="image" src="https://github.com/user-attachments/assets/ddcde9b2-edef-45ae-8bc5-f39899d4f29e" />

<img width="568" height="766" alt="image" src="https://github.com/user-attachments/assets/b6612d1e-0e97-4da5-b8dc-ba746532769a" />

mysql 상에서도 과제 댓글이 잘 저장된 것을 확인할 수 있습니다.

```jsx
mysql> select * from assignment_comment;
+------------+----------------------------+------------+------------+--------------+-----------+---------+
| comment_id | created_at                 | deleted_at | updated_at | content      | assign_id | user_id |
+------------+----------------------------+------------+------------+--------------+-----------+---------+
|          1 | 2025-08-13 20:34:32.581061 | NULL       | NULL       | ??? ? ????   |         3 |       2 |
|          2 | 2025-08-13 20:39:24.253558 | NULL       | NULL       | ?? ?? ?? ??? |         3 |       2 |
+------------+----------------------------+------------+------------+--------------+-----------+---------+
2 rows in set (0.00 sec)
```

**2번째 테스트로 제출한 과제를 수정, 삭제해보겠습니다**

먼저 테스트용 과제 하나를 제출합니다

<img width="538" height="554" alt="image" src="https://github.com/user-attachments/assets/d0726fe7-3d62-43b9-b10c-339ec6cae8f3" />

이를 수정하면

<img width="679" height="617" alt="image" src="https://github.com/user-attachments/assets/c3017a90-243c-4500-8e5b-3bab6144f245" />

수정이 잘 됩니당

삭제하고 조회해보겠습니다

<img width="539" height="345" alt="image" src="https://github.com/user-attachments/assets/03e92424-9a6f-4490-b40e-9cb34ad42ecb" />

제출한 과제가 없어졌습니다

<img width="624" height="601" alt="image" src="https://github.com/user-attachments/assets/d06d57f0-720b-4d23-b222-a88ca9f0d157" />

반대로 존재한다면 과제 제출 조회가 잘 되는지 테스트하겠습니다

<img width="561" height="528" alt="image" src="https://github.com/user-attachments/assets/29bddce4-8d2a-4de4-ac1f-501a93582a09" />

이런 식으로 잘 나옵니다.

참고로 user별로 과제 제출한 거 확인하는 건 멘토/멘티(제출한 본인만) 모두 가능합니다.

스터디 멤버가 아닌 경우

<img width="497" height="197" alt="image" src="https://github.com/user-attachments/assets/c5919afe-93ee-49c3-8531-344b72a138b0" />

제출한 본인이 아닌 경우

<img width="581" height="552" alt="image" src="https://github.com/user-attachments/assets/d3dcb720-a107-4317-b71b-7b2319bbd67c" />

그리고 전체 과제 제출 리스트를 확인할 수 있습니다. (멘토/멘티 둘 다)

<img width="588" height="695" alt="image" src="https://github.com/user-attachments/assets/9120a327-16e9-42ad-b8a5-94259e81b7cb" />

**과제 피드백 남기기**

멘토만 남길 수 있다.

<img width="571" height="471" alt="image" src="https://github.com/user-attachments/assets/a3296986-05fb-4ccf-be0b-4020258a8641" />

과제 피드백 남기기 성공

<img width="555" height="396" alt="image" src="https://github.com/user-attachments/assets/2a08a40d-ca8e-448b-a28e-a66f521f950d" />

<img width="567" height="533" alt="image" src="https://github.com/user-attachments/assets/6dcf93b0-3fbe-4b86-a630-e091d7b9c3d6" />

---

### **의문점**

과제에 대한 댓글 생성할 때 생긴 의문입니다.

다른 Dto들의 경우, 생성자를 따로 요구하지 않았습니다만,,,,

**오류 내용**

```jsx
org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Cannot construct instance of `com.mjsec.lms.dto.AssignmentCommentDto` (although at least one Creator exists): cannot deserialize from Object value (no delegate- or property-based Creator)
```

그래서 뭐지 싶어서 찾아보니 Jackson 역직렬화 오류라고는 하는데 다른 기능, Dto에서는 못 보던 에러라 당황했습니다.

```jsx
package com.mjsec.lms.dto;

import jakarta.validation.constraints.NotBlank;
import lombok.AllArgsConstructor;
import lombok.Builder;
import lombok.Data;
import lombok.NoArgsConstructor;

@Data
@Builder
@NoArgsConstructor
@AllArgsConstructor
public class AssignmentCommentDto {

    @NotBlank(message = "댓글을 입력해주세요!")
    private String content;
}

```

물론 해결은 Dto에 생성자를 설정해주면 되긴 하지만… 다른 Dto의 경우에는 생성자를 주입하지 않아도 잘 돌아갔었는데 왜 이 AssignmentCommentDto만 그런건지 모르겠습니다. 😟

테스트해보다 보니 `SubmissionFeedbackDto`  과제 피드백 남기기 Dto에서도 똑같은 현상이 일어나서 생성자 생성자를 설정해줬습니다.

---

### 앞으로 할 거? + 개인적인 생각

일단 과제 피드백이 올라가게만 해놔서 수정, 삭제같은 게 없습니다. 이걸 추가하려고 해요

그리고 과제 피드백을 좀 더 강화하면 좋을 거 같다는 생각이 드네요 아예 과제 피드백 테이블을 따로 만들어서 연결시키는 건 어떨까 생각중입니다.

근데 또 과제 피드백을 그렇게까지 할 필요가 있나? 싶긴 한디 여러분들의 의견 코멘트 부탁드립니다

어렵네용…
