### PR TITLE
fix: 전체 공지사항 최신 순으로 반환하기

### DIFF
--- a/src/main/java/com/mjsec/lms/service/AnnouncementService.java
+++ b/src/main/java/com/mjsec/lms/service/AnnouncementService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -69,16 +70,17 @@ public class AnnouncementService {
     public List<AnnouncementResponseDto> getAnnouncements(Long currentUserStudentNumber ) {
 
         //전체 공지사항을  조회하려는 유저 확인하기
-       User user = validateUser(currentUserStudentNumber);
+        User user = validateUser(currentUserStudentNumber);
 
-       //공지사항이 존재하는지 확인하기
+        //공지사항이 존재하는지 확인하기
         List<Announcement> announcements = announcementRepository.findAll();
-        if(announcements.isEmpty()) {
+        if (announcements.isEmpty()) {
             throw new RestApiException(ErrorCode.ANNOUNCEMENT_NOT_FOUND);
         }
 
         return announcements.stream()
-                .map((AnnouncementMapper::toDto))
+                .sorted(Comparator.comparing(Announcement::getAnnouncementId).reversed())
+                .map(AnnouncementMapper::toDto)
                 .collect(Collectors.toList());
     }
 
@@ -112,6 +114,7 @@ public class AnnouncementService {
         //작성자 본인 확인
         if(!announcement.getCreator().getUserId().equals(user.getUserId())) {
             throw new RestApiException(ErrorCode.ANNOUNCEMENT_FORBIDDEN);
+        }
 
         //데이터가 null이 아닌 경우에만 업데이트
         if (dto.getTitle() != null && !dto.getTitle().trim().isEmpty()) {


### PR DESCRIPTION
전체 회의 시간에 받은 피드백을 바탕으로 수정했습니당~
모든 공지사항 반환할 때 게시물이 오래된 순서대로 정렬되어 있어서 이 부분을 역순으로 수정했습니다.
최신 공지사항이 가장 위에 뜨도록!(생각을 못 해쑴 히히)
<img width="628" height="678" alt="스크린샷 2025-09-01 오전 9 43 04" src="https://github.com/user-attachments/assets/b1516249-15e5-41f6-8af7-a0397cead42e" />


<img width="628" height="678" alt="스크린샷 2025-09-01 오전 9 43 26" src="https://github.com/user-attachments/assets/7c5dab4a-9f6b-444f-b1f5-4cfe702ae8d9" />

최신 게시물이 가장 위에 뜨도록 해쑴당 