### PR TITLE
feat(mentor): add append group member and delete group member feature

### DIFF
--- a/src/main/java/com/mjsec/lms/LmsApplication.java
+++ b/src/main/java/com/mjsec/lms/LmsApplication.java
@@ -2,9 +2,9 @@ package com.mjsec.lms;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaRepositories
+@EnableJpaAuditing
 @SpringBootApplication
 public class LmsApplication {
 

--- a/src/main/java/com/mjsec/lms/config/SecurityConfig.java
+++ b/src/main/java/com/mjsec/lms/config/SecurityConfig.java
@@ -81,8 +81,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/v1/users/announcements/**").hasAnyRole("ADMIN", "USER")
                         .requestMatchers("/api/v1/users/**").permitAll() // 임시로 허용
-                        .requestMatchers("/api/v1/mentor/**").hasAnyRole("ADMIN, USER")
-
+                        .requestMatchers("/api/v1/mentor/**").hasAnyRole("ADMIN", "USER")
                 );
 
         return http.build();

--- a/src/main/java/com/mjsec/lms/config/SecurityConfig.java
+++ b/src/main/java/com/mjsec/lms/config/SecurityConfig.java
@@ -81,6 +81,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/v1/users/announcements/**").hasAnyRole("ADMIN", "USER")
                         .requestMatchers("/api/v1/users/**").permitAll() // 임시로 허용
+                        .requestMatchers("/api/v1/mentor/**").hasAnyRole("ADMIN, USER")
 
                 );
 

--- a/src/main/java/com/mjsec/lms/controller/MentorController.java
+++ b/src/main/java/com/mjsec/lms/controller/MentorController.java
@@ -1,0 +1,40 @@
+package com.mjsec.lms.controller;
+
+import com.mjsec.lms.dto.SuccessResponse;
+import com.mjsec.lms.repository.StudyGroupRepository;
+import com.mjsec.lms.repository.UserRepository;
+import com.mjsec.lms.service.MentorService;
+import com.mjsec.lms.type.ResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mentor")
+public class MentorController {
+
+    private final MentorService mentorService;
+
+    @PostMapping("/group/{groupId}/add-member/{studentNumber}")
+    public ResponseEntity<SuccessResponse<Void>> addMember(
+            @PathVariable("groupId") Long groupId,
+            @PathVariable("studentNumber") Long studentNumber,
+            Authentication authentication)
+    {
+
+        Long currentStudentNumber = (Long) authentication.getPrincipal();
+        mentorService.addMember(currentStudentNumber, groupId, studentNumber);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.ADD_MEMBER_SUCCESS
+                )
+        );
+    }
+}

--- a/src/main/java/com/mjsec/lms/controller/MentorController.java
+++ b/src/main/java/com/mjsec/lms/controller/MentorController.java
@@ -1,14 +1,13 @@
 package com.mjsec.lms.controller;
 
 import com.mjsec.lms.dto.SuccessResponse;
-import com.mjsec.lms.repository.StudyGroupRepository;
-import com.mjsec.lms.repository.UserRepository;
 import com.mjsec.lms.service.MentorService;
 import com.mjsec.lms.type.ResponseMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,6 +33,22 @@ public class MentorController {
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessResponse.of(
                         ResponseMessage.ADD_MEMBER_SUCCESS
+                )
+        );
+    }
+
+    @DeleteMapping("/group/{groupId}/delete-member/{studentNumber}")
+    public ResponseEntity<SuccessResponse<Void>> deleteMember(
+            @PathVariable("groupId") Long groupId,
+            @PathVariable("studentNumber") Long studentNumber,
+            Authentication authentication)
+    {
+        Long currentStudentNumber = (Long) authentication.getPrincipal();
+        mentorService.deleteMember(currentStudentNumber, groupId, studentNumber);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.DELETE_MEMBER_SUCCESS
                 )
         );
     }

--- a/src/main/java/com/mjsec/lms/repository/StudyGroupRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/StudyGroupRepository.java
@@ -1,9 +1,12 @@
 package com.mjsec.lms.repository;
 
 import com.mjsec.lms.domain.StudyGroup;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
 
     boolean existsByName(String name);
+
+    Optional<StudyGroup> findByStudyId(Long studyId);
 }

--- a/src/main/java/com/mjsec/lms/service/MentorService.java
+++ b/src/main/java/com/mjsec/lms/service/MentorService.java
@@ -1,0 +1,52 @@
+package com.mjsec.lms.service;
+
+import com.mjsec.lms.domain.GroupMember;
+import com.mjsec.lms.domain.StudyGroup;
+import com.mjsec.lms.domain.User;
+import com.mjsec.lms.exception.RestApiException;
+import com.mjsec.lms.repository.GroupMemberRepository;
+import com.mjsec.lms.repository.StudyGroupRepository;
+import com.mjsec.lms.repository.UserRepository;
+import com.mjsec.lms.type.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class MentorService {
+
+    private final UserRepository userRepository;
+    private final StudyGroupRepository studyGroupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    public MentorService(UserRepository userRepository, StudyGroupRepository studyGroupRepository,
+                         GroupMemberRepository groupMemberRepository) {
+
+        this.userRepository = userRepository;
+        this.studyGroupRepository = studyGroupRepository;
+        this.groupMemberRepository = groupMemberRepository;
+    }
+
+    public void addMember(Long currentStudentNumber, Long groupId, Long studentNumber) {
+
+        User user = userRepository.findByStudentNumber(currentStudentNumber)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+        StudyGroup studyGroup = studyGroupRepository.findByStudyId(groupId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_NOT_FOUND));
+
+        if(user != studyGroup.getCreator()) {
+            throw new RestApiException(ErrorCode.MENTOR_ONLY_CAN_ADD_MEMBER);
+        }
+
+        User mentee = userRepository.findByStudentNumber(studentNumber)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+        GroupMember groupMember = GroupMember.builder()
+                .user(mentee)
+                .studyGroup(studyGroup)
+                .build();
+
+        groupMemberRepository.save(groupMember);
+    }
+}

--- a/src/main/java/com/mjsec/lms/service/MentorService.java
+++ b/src/main/java/com/mjsec/lms/service/MentorService.java
@@ -8,6 +8,7 @@ import com.mjsec.lms.repository.GroupMemberRepository;
 import com.mjsec.lms.repository.StudyGroupRepository;
 import com.mjsec.lms.repository.UserRepository;
 import com.mjsec.lms.type.ErrorCode;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -41,7 +42,7 @@ public class MentorService {
         StudyGroup studyGroup = studyGroupRepository.findByStudyId(groupId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_NOT_FOUND));
 
-        if(user != studyGroup.getCreator()) {
+        if(!Objects.equals(user.getUserId(), studyGroup.getCreator().getUserId())) {
             throw new RestApiException(ErrorCode.MENTOR_ONLY_CAN_ADD_MEMBER);
         }
 
@@ -70,7 +71,7 @@ public class MentorService {
         StudyGroup studyGroup = studyGroupRepository.findByStudyId(groupId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_NOT_FOUND));
 
-        if(user != studyGroup.getCreator()) {
+        if(!Objects.equals(user.getUserId(), studyGroup.getCreator().getUserId())) {
             throw new RestApiException(ErrorCode.MENTOR_ONLY_CAN_DELETE_MEMBER);
         }
 

--- a/src/main/java/com/mjsec/lms/service/MentorService.java
+++ b/src/main/java/com/mjsec/lms/service/MentorService.java
@@ -27,6 +27,12 @@ public class MentorService {
         this.groupMemberRepository = groupMemberRepository;
     }
 
+    /**
+     * 스터디 그룹에 멘티를 추가하는 메소드
+     * @param currentStudentNumber 요청을 보낸 사용자의 학번
+     * @param groupId 스터디 그룹의 Id
+     * @param studentNumber 스터디 그룹 멘티의 학번
+     */
     public void addMember(Long currentStudentNumber, Long groupId, Long studentNumber) {
 
         User user = userRepository.findByStudentNumber(currentStudentNumber)
@@ -48,5 +54,32 @@ public class MentorService {
                 .build();
 
         groupMemberRepository.save(groupMember);
+    }
+
+    /**
+     * 스터디 그룹에서 특정 멘티를 삭제시키는 메소드
+     * @param currentStudentNumber 요청을 보낸 사용자의 학번
+     * @param groupId 스터디 그룹의 Id
+     * @param studentNumber 스터디 그룹 멘티의 학번
+     */
+    public void deleteMember(Long currentStudentNumber, Long groupId, Long studentNumber) {
+
+        User user = userRepository.findByStudentNumber(currentStudentNumber)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+        StudyGroup studyGroup = studyGroupRepository.findByStudyId(groupId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_NOT_FOUND));
+
+        if(user != studyGroup.getCreator()) {
+            throw new RestApiException(ErrorCode.MENTOR_ONLY_CAN_DELETE_MEMBER);
+        }
+
+        User mentee = userRepository.findByStudentNumber(studentNumber)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+        GroupMember groupMember = groupMemberRepository.findByUserAndStudyGroup(mentee, studyGroup)
+                .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
+
+        groupMemberRepository.delete(groupMember);
     }
 }

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -79,7 +79,8 @@ public enum ErrorCode {
     ANNOUNCEMENT_FORBIDDEN(HttpStatus. FORBIDDEN,"본인이 작성한 공지사항만 수정/삭제할 수 있습니다."),
 
     //멘토
-    MENTOR_ONLY_CAN_ADD_MEMBER(HttpStatus.BAD_REQUEST, "멘토만 스터디원을 추가할 수 있습니다.")
+    MENTOR_ONLY_CAN_ADD_MEMBER(HttpStatus.BAD_REQUEST, "멘토만 스터디원을 추가할 수 있습니다."),
+    MENTOR_ONLY_CAN_DELETE_MEMBER(HttpStatus.BAD_REQUEST, "멘토만 스터디원을 삭제할 수 있습니다.")
     ;
   
     private final HttpStatus status;

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -69,13 +69,18 @@ public enum ErrorCode {
     //출석 체크
     DUPLICATE_ATTENDANCE_CHECK(HttpStatus.BAD_REQUEST, "중복된 출석체크입니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "끝일자가 시작일자보다 빠릅니다."),
+
     //공지사항
     ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다."),
-    ANNOUNCEMENT_UNAUTHORIZED_ROLE(HttpStatus.FORBIDDEN, "관리자만 관리할 수 있습니다.."),
+    ANNOUNCEMENT_UNAUTHORIZED_ROLE(HttpStatus.FORBIDDEN, "관리자만 관리할 수 있습니다."),
     ANNOUNCEMENT_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "공지 타입은 필수입니다."),
     ANNOUNCEMENT_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "공지사항 제목은 필수입니다."),
     ANNOUNCEMENT_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "공지사항 내용은 필수입니다."),
-    ANNOUNCEMENT_FORBIDDEN(HttpStatus. FORBIDDEN,"본인이 작성한 공지사항만 수정/삭제할 수 있습니다. ");
+    ANNOUNCEMENT_FORBIDDEN(HttpStatus. FORBIDDEN,"본인이 작성한 공지사항만 수정/삭제할 수 있습니다."),
+
+    //멘토
+    MENTOR_ONLY_CAN_ADD_MEMBER(HttpStatus.BAD_REQUEST, "멘토만 스터디원을 추가할 수 있습니다.")
+    ;
   
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -38,16 +38,19 @@ public enum ResponseMessage {
     FEEDBACK_UPDATE_SUCCESS("과제 피드백 수정 성공"),
     FEEDBACK_DELETE_SUCCESS("과제 피드백 삭제 성공"),
 
-    //출석체크
+    // 출석체크 관련
     ATTENDANCE_GET_SUCCESS("출석체크 조회 성공"),
     ATTENDANCE_CREATE_SUCCESS("출석체크 성공"),
 
-    // Announcement관련
+    // Announcement 관련
     POST_ANNOUNCEMENT_SUCCESS("공지사항 등록 성공"),
     GET_ANNOUNCEMENT_SUCCESS("전체 공지사항 목록 반환 성공"),
     DETAIL_ANNOUNCEMENT_SUCCESS("공지사항 상제 조회 성공"),
     UPDATE_ANNOUNCEMENT_SUCCESS("공지사항 수정 성공"),
-    DELETE_ANNOUNCEMENT_SUCCESS("공지사항 삭제 성공")
+    DELETE_ANNOUNCEMENT_SUCCESS("공지사항 삭제 성공"),
+
+    // Mentor 관련
+    ADD_MEMBER_SUCCESS("스터디원 추가 성공")
     ;
     private final String message;
 }

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -50,7 +50,8 @@ public enum ResponseMessage {
     DELETE_ANNOUNCEMENT_SUCCESS("공지사항 삭제 성공"),
 
     // Mentor 관련
-    ADD_MEMBER_SUCCESS("스터디원 추가 성공")
+    ADD_MEMBER_SUCCESS("스터디원 추가 성공"),
+    DELETE_MEMBER_SUCCESS("스터디원 삭제 성공")
     ;
     private final String message;
 }


### PR DESCRIPTION
## 변경사항

- 중요한 수정이 있었습니다. 거의 모든 엔티티(domain)가 BaseEntity를 상속 받아 created_at, updated_at, deleted_at을 컬럼으로 가지게 되는데 세 값 모두 null이 들어가는 문제가 있었습니다.
<img width="724" height="133" alt="스크린샷 2025-09-01 오후 4 40 44" src="https://github.com/user-attachments/assets/010406ad-3f7d-4503-939d-45b48002a914" />

그 이유는 바로 제가 LmsApplication.java에서 EnableJpaAuditing이 아닌 EnableJpaRepositories 어노테이션을 붙였기 때문이죠...
(우리 모두 어떤 어노테이션을 사용하는지, 어떤 라이브러리를 import 하는지 잘 확인합시다 😅)

참고로 EnableJpaAuditing이 메인 함수가 있는 클래스에 붙어있어야 엔티티 생성, 수정, 삭제가 일어났을 때 시각이 잘 들어가게 됩니다. 
(EnableJpaRepositories 어노테이션은 스프링에서 레포지토리를 스캔할 때 사용합니다.)

따라서 메인 클래스를 다음과 같이 변경하였습니다.
<img width="829" height="225" alt="스크린샷 2025-09-01 오후 5 20 34" src="https://github.com/user-attachments/assets/2f2c2431-0de3-46de-befb-7bb16c95082e" />

그리고 엔티티 생성, 수정, 삭제가 일어났을 때 다음과 같이 잘 업데이트 되는 모습을 볼 수 있습니다.
<img width="978" height="152" alt="스크린샷 2025-09-01 오후 5 03 47" src="https://github.com/user-attachments/assets/d66c9d11-b749-40f1-8dbd-27426b8e1842" />

---

## 추가된 기능 1 (API 명세서 수정 완료)

- 멘토 권한으로 스터디 그룹에 멤버(멘티)를 추가하는 기능이 추가되었습니다. 
<img width="571" height="337" alt="스크린샷 2025-09-01 오후 5 24 17" src="https://github.com/user-attachments/assets/f6e7a020-d72a-41d7-afd5-87d322859766" />
스터디 그룹의 Id와 추가하고자 하는 멘티의 학번을 PathVariable로 받습니다.

테스트는 Postman으로 진행하였습니다.

<img width="1470" height="920" alt="스크린샷 2025-09-01 오후 4 37 24" src="https://github.com/user-attachments/assets/78bb9304-ff68-43bb-a410-8eef697c1ae9" />
만약 해당 스터디 그룹의 멘토가 아님에도 멘티를 추가하려는 경우 예외 처리가 발생합니다. (스터디 삭제 시에도 동일)

다음은 성공했을 때의 응답입니다.
<img width="1470" height="920" alt="스크린샷 2025-09-01 오후 4 39 36" src="https://github.com/user-attachments/assets/72253f8c-55c8-4ba5-886d-abafafa1e72d" />

---

## 추가된 기능 2 (API 명세서 수정 완료)

- 멘토 권한으로 스터디 그룹에서 멘티를 삭제하는 기능이 추가되었습니다. (기본적으로 GroupMember 레포지토리에서 삭제만 하며, 의존 관계에 있는 출석이나 과제 처리 같은 경우는 추후 회의 후에 업데이트 예정입니다.)
<img width="571" height="119" alt="스크린샷 2025-09-01 오후 5 33 28" src="https://github.com/user-attachments/assets/a1a7770c-7f49-4c9d-9717-32b082b5c5f1" />
동일하게 스터디 그룹의 Id와 추가하고자 하는 멘티의 학번을 PathVariable로 받습니다.

테스트 결과는 다음과 같습니다.
<img width="1470" height="920" alt="스크린샷 2025-09-01 오후 5 05 02" src="https://github.com/user-attachments/assets/1f9b962f-1cc0-4400-8a0e-f857d4b6db08" />

DB에서 확인해보면 deleted_at 에 값이 정상적으로 들어가는 것을 볼 수 있습니다.
<img width="1108" height="144" alt="스크린샷 2025-09-01 오후 5 05 20" src="https://github.com/user-attachments/assets/19a5f15c-a471-4ffc-b816-7ca402a5300e" />

---

P.S
<img width="260" height="194" alt="image" src="https://github.com/user-attachments/assets/6af842ff-2dcf-4c27-8093-987f8b7f214a" />