### PR TITLE
feat(warn): add mentee warning system

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/MentorController.java
+++ b/src/main/java/com/mjsec/lms/controller/MentorController.java
@@ -43,12 +43,30 @@ public class MentorController {
             @PathVariable("studentNumber") Long studentNumber,
             Authentication authentication)
     {
+
         Long currentStudentNumber = (Long) authentication.getPrincipal();
         mentorService.deleteMember(currentStudentNumber, groupId, studentNumber);
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessResponse.of(
                         ResponseMessage.DELETE_MEMBER_SUCCESS
+                )
+        );
+    }
+
+    @PostMapping("/warn/{groupId}/{studentNumber}")
+    public ResponseEntity<SuccessResponse<Void>> warnMember(
+            @PathVariable("groupId") Long groupId,
+            @PathVariable("studentNumber") Long studentNumber,
+            Authentication authentication)
+    {
+
+        Long currentStudentNumber = (Long) authentication.getPrincipal();
+        mentorService.warnMember(currentStudentNumber, groupId, studentNumber);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.WARN_MEMBER_SUCCESS
                 )
         );
     }

--- a/src/main/java/com/mjsec/lms/service/MentorService.java
+++ b/src/main/java/com/mjsec/lms/service/MentorService.java
@@ -106,12 +106,10 @@ public class MentorService {
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
 
         groupMember.setWarn(groupMember.getWarn() + 1);
+        groupMemberRepository.save(groupMember);
 
         if(groupMember.getWarn() == 3) {
             groupMemberRepository.delete(groupMember);
-        }
-        else {
-            groupMemberRepository.save(groupMember);
         }
     }
 }

--- a/src/main/java/com/mjsec/lms/service/MentorService.java
+++ b/src/main/java/com/mjsec/lms/service/MentorService.java
@@ -29,12 +29,12 @@ public class MentorService {
     }
 
     /**
-     * 스터디 그룹에 멘티를 추가하는 메소드
+     * 요청을 보낸 사용자가 해당 스터디그룹의 멘토라면 StudyGroup 엔티티를 반환하는 메소드
      * @param currentStudentNumber 요청을 보낸 사용자의 학번
      * @param groupId 스터디 그룹의 Id
-     * @param studentNumber 스터디 그룹 멘티의 학번
+     * @return StudyGroup 스터디 그룹 엔티티
      */
-    public void addMember(Long currentStudentNumber, Long groupId, Long studentNumber) {
+    public StudyGroup checkMentor(Long currentStudentNumber, Long groupId) {
 
         User user = userRepository.findByStudentNumber(currentStudentNumber)
                 .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
@@ -43,8 +43,21 @@ public class MentorService {
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_NOT_FOUND));
 
         if(!Objects.equals(user.getUserId(), studyGroup.getCreator().getUserId())) {
-            throw new RestApiException(ErrorCode.MENTOR_ONLY_CAN_ADD_MEMBER);
+            throw new RestApiException(ErrorCode.MENTOR_ONLY_CAN_DELETE_MEMBER);
         }
+
+        return studyGroup;
+    }
+
+    /**
+     * 스터디 그룹에 멘티를 추가하는 메소드
+     * @param currentStudentNumber 요청을 보낸 사용자의 학번
+     * @param groupId 스터디 그룹의 Id
+     * @param studentNumber 스터디 그룹 멘티의 학번
+     */
+    public void addMember(Long currentStudentNumber, Long groupId, Long studentNumber) {
+
+        StudyGroup studyGroup = checkMentor(currentStudentNumber, groupId);
 
         User mentee = userRepository.findByStudentNumber(studentNumber)
                 .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
@@ -65,15 +78,7 @@ public class MentorService {
      */
     public void deleteMember(Long currentStudentNumber, Long groupId, Long studentNumber) {
 
-        User user = userRepository.findByStudentNumber(currentStudentNumber)
-                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
-
-        StudyGroup studyGroup = studyGroupRepository.findByStudyId(groupId)
-                .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_NOT_FOUND));
-
-        if(!Objects.equals(user.getUserId(), studyGroup.getCreator().getUserId())) {
-            throw new RestApiException(ErrorCode.MENTOR_ONLY_CAN_DELETE_MEMBER);
-        }
+        StudyGroup studyGroup = checkMentor(currentStudentNumber, groupId);
 
         User mentee = userRepository.findByStudentNumber(studentNumber)
                 .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
@@ -82,5 +87,31 @@ public class MentorService {
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
 
         groupMemberRepository.delete(groupMember);
+    }
+
+    /**
+     * 멘티에게 수동으로 경고를 부여하는 메소드 (경고 3번 누적 시 스터디 자동 퇴출)
+     * @param currentStudentNumber 요청을 보낸 사용자의 학번
+     * @param groupId 스터디 그룹의 Id
+     * @param studentNumber 스터디 그룹 멘티의 학번
+     */
+    public void warnMember(Long currentStudentNumber, Long groupId, Long studentNumber) {
+
+        StudyGroup studyGroup = checkMentor(currentStudentNumber, groupId);
+
+        User mentee = userRepository.findByStudentNumber(studentNumber)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+        GroupMember groupMember = groupMemberRepository.findByUserAndStudyGroup(mentee, studyGroup)
+                .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
+
+        groupMember.setWarn(groupMember.getWarn() + 1);
+
+        if(groupMember.getWarn() == 3) {
+            groupMemberRepository.delete(groupMember);
+        }
+        else {
+            groupMemberRepository.save(groupMember);
+        }
     }
 }

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -54,8 +54,8 @@ public enum ResponseMessage {
 
     // Mentor 관련
     ADD_MEMBER_SUCCESS("스터디원 추가 성공"),
-    DELETE_MEMBER_SUCCESS("스터디원 삭제 성공")
-
+    DELETE_MEMBER_SUCCESS("스터디원 삭제 성공"),
+    WARN_MEMBER_SUCCESS("수동 경고 부여 성공")
     ;
     private final String message;
 }


### PR DESCRIPTION
## 변경사항

멘토 권한으로 멘티에게 경고를 부여하는 기능이 추가되었습니다.
<img width="493" height="56" alt="스크린샷 2025-09-03 오후 1 09 32" src="https://github.com/user-attachments/assets/9d364f05-6a49-4d01-99cb-07b5a89c06bf" />

그룹에 속한 멘티에게 경고를 부여하는 것이기 때문에 groupId(스터디 그룹 Id)와 studentNumber(멘티 학번)을 PathVariable로 받습니다.

API 요청을 보낼 때마다 경고 횟수를 저장하는 컬럼 warn에 1씩 누적이 됩니다.
경고 3회가 되는 순간 동아리에서 퇴출됩니다.
<img width="402" height="185" alt="스크린샷 2025-09-03 오후 1 13 12" src="https://github.com/user-attachments/assets/579ca10b-2c8e-4561-9056-082d87409041" />

## 테스트 : Postman

테스트는 새롭게 멤버 하나를 추가하여 진행하였습니다.
<img width="1260" height="946" alt="스크린샷 2025-09-02 오전 11 46 54" src="https://github.com/user-attachments/assets/a0973075-d851-4681-b73a-b8ff1688ddda" />

다음으로, 멘티에게 경고를 하나 부여해봅니다.
<img width="1260" height="946" alt="스크린샷 2025-09-03 오후 1 15 53" src="https://github.com/user-attachments/assets/bf48eded-6c66-47b0-8764-162da230562c" />

3번 경고를 부여하는 순간 deleted_at에 시각에 들어가게 됩니다.
<img width="1111" height="405" alt="스크린샷 2025-09-02 오후 1 00 44" src="https://github.com/user-attachments/assets/1d62db8a-b043-40f3-bc7f-e5daa6983f31" />
