### PR TITLE
fix(add-member): add checking for already exist member

### DIFF
--- a/src/main/java/com/mjsec/lms/repository/GroupMemberRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/GroupMemberRepository.java
@@ -27,4 +27,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 
     //특정 스터디 그룹의 모든 멤버 조회
     List<GroupMember> findByStudyGroup_StudyId(Long studyId);
+
+    // 유저와 스터디 그룹 정보를 받아 이미 있는 멤버인지 확인
+    boolean existsByUserAndStudyGroup(User user, StudyGroup studyGroup);
 }

--- a/src/main/java/com/mjsec/lms/service/MentorService.java
+++ b/src/main/java/com/mjsec/lms/service/MentorService.java
@@ -62,6 +62,10 @@ public class MentorService {
         User mentee = userRepository.findByStudentNumber(studentNumber)
                 .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
 
+        if(groupMemberRepository.existsByUserAndStudyGroup(mentee, studyGroup)){
+            throw new RestApiException(ErrorCode.ALREADY_JOINED_GROUP);
+        }
+
         GroupMember groupMember = GroupMember.builder()
                 .user(mentee)
                 .studyGroup(studyGroup)

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -80,7 +80,8 @@ public enum ErrorCode {
 
     //멘토
     MENTOR_ONLY_CAN_ADD_MEMBER(HttpStatus.BAD_REQUEST, "멘토만 스터디원을 추가할 수 있습니다."),
-    MENTOR_ONLY_CAN_DELETE_MEMBER(HttpStatus.BAD_REQUEST, "멘토만 스터디원을 삭제할 수 있습니다.")
+    MENTOR_ONLY_CAN_DELETE_MEMBER(HttpStatus.BAD_REQUEST, "멘토만 스터디원을 삭제할 수 있습니다."),
+    ALREADY_JOINED_GROUP(HttpStatus.BAD_REQUEST, "이미 스터디 그룹에 속해 있는 멘티 입니다.")
     ;
   
     private final HttpStatus status;


### PR DESCRIPTION
## 변경사항

특별할 건 없고 단순한 체킹 로직이 들어갔습니다.
멘토 권한으로 그룹에 멤버를 추가시킬 때 이미 존재하는 멤버인지 체크하는 로직이 빠져있어서 예외를 발생시키는 분기문을 추가하였습니다. 
<img width="633" height="86" alt="스크린샷 2025-09-03 오후 6 47 06" src="https://github.com/user-attachments/assets/859cae57-0d9a-40e2-b67f-54a468e9a39d" />

만약 이 로직이 빠져있으면 500 상태코드와 함께 다음과 같은 에러가 뜨게 됩니다.
<img width="1172" height="26" alt="image" src="https://github.com/user-attachments/assets/00362f7b-dd51-43b9-849a-78f6c8033073" />

---

P.S 수요일 8시간 수업 죽고싶다.
<img width="247" height="204" alt="image" src="https://github.com/user-attachments/assets/735621cb-c100-4a2e-8a4c-ed49f8648674" />
