### PR TITLE
fix: Announcement domain delete

### DIFF
--- a/src/main/java/com/mjsec/lms/config/SecurityConfig.java
+++ b/src/main/java/com/mjsec/lms/config/SecurityConfig.java
@@ -79,8 +79,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/groups/**").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
-                        .requestMatchers("/api/v1/users/announcements/**").hasAnyRole("ADMIN", "USER")
-                        .requestMatchers("/api/v1/users/**").permitAll() // 임시로 허용
+                        .requestMatchers("/api/v1/user/announcements/**").hasAnyRole("ADMIN", "USER")
+                        .requestMatchers("/api/v1/user/**").permitAll() // 임시로 허용
 
                 );
 

--- a/src/main/java/com/mjsec/lms/controller/AnnouncementController.java
+++ b/src/main/java/com/mjsec/lms/controller/AnnouncementController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/users/")
+@RequestMapping("/api/v1/user/")
 public class AnnouncementController {
 
     private final AnnouncementService announcementService;

--- a/src/main/java/com/mjsec/lms/domain/Announcement.java
+++ b/src/main/java/com/mjsec/lms/domain/Announcement.java
@@ -32,12 +32,6 @@ public class Announcement extends BaseEntity {
     @Column(length = 50)
     private AnnouncementRole type;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime updatedAt;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User creator;


### PR DESCRIPTION
그 유찬쌤 피드백 그대로 수정했습니당. 정상적으로 작동하는 것도 확인했어요!
Announcement 도메인에서 updateAt createdAt 이거 삭제했고, 
api 경로 users/announcements -> user/announcements 이런식으로 users를 user로 변경했습니다. 