### PR TITLE
Fix : 과제 미제출자 메일 로직 수정

### DIFF
--- a/src/main/java/com/mjsec/lms/repository/PlanRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/PlanRepository.java
@@ -31,10 +31,16 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     );
 
     //특정 스터디 그룹의 마감된 과제들 조회
-    @Query("SELECT a FROM Plan a WHERE a.studyGroup.studyId = :studyId AND a.endDate < :currentTime")
-    List<Plan> findExpiredPlansByStudyGroup(
+    @Query("SELECT p FROM Plan p WHERE p.studyGroup.studyId = :studyId AND p.endDate < :currentTime AND p.hasAssignment = true")
+    List<Plan> findExpiredAssignmentsByStudyGroup(
             @Param("studyId") Long studyId,
             @Param("currentTime") LocalDateTime currentTime
+    );
+
+    @Query("SELECT p FROM Plan p WHERE p.endDate BETWEEN :startTime AND :endTime AND p.hasAssignment = true")
+    List<Plan> findAssignmentsExpiredBetween(
+            @Param("startTime") LocalDateTime startTime,
+            @Param("endTime") LocalDateTime endTime
     );
 
     @Modifying

--- a/src/main/java/com/mjsec/lms/security/CustomLoginFilter.java
+++ b/src/main/java/com/mjsec/lms/security/CustomLoginFilter.java
@@ -109,6 +109,9 @@ public class CustomLoginFilter extends GenericFilterBean {
     }
 
     private void sendErrorResponse(HttpServletResponse response, int status, ErrorCode errorCode) throws IOException {
+        response.setHeader("Access-Control-Allow-Origin", "http://localhost:5173");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
+
         response.setStatus(status);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/mjsec/lms/security/CustomLoginFilter.java
+++ b/src/main/java/com/mjsec/lms/security/CustomLoginFilter.java
@@ -109,8 +109,6 @@ public class CustomLoginFilter extends GenericFilterBean {
     }
 
     private void sendErrorResponse(HttpServletResponse response, int status, ErrorCode errorCode) throws IOException {
-        response.setHeader("Access-Control-Allow-Origin", "http://localhost:5173");
-        response.setHeader("Access-Control-Allow-Credentials", "true");
 
         response.setStatus(status);
         response.setContentType("application/json");

--- a/src/main/java/com/mjsec/lms/service/ScheduledTaskService.java
+++ b/src/main/java/com/mjsec/lms/service/ScheduledTaskService.java
@@ -53,7 +53,7 @@ public class ScheduledTaskService {
     }
     
     // 테스트용 - 30초마다 실행 (개발/테스트시에만 사용) - 과제 알람
-    //@Scheduled(fixedRate = 30000)
+    @Scheduled(fixedRate = 30000)
     public void testScheduler() {
         log.info("Test scheduler executed at: {}", java.time.LocalDateTime.now());
         // 테스트 시에는 아래 주석을 해제해서 사용

--- a/src/main/java/com/mjsec/lms/service/WeeklyAlertService.java
+++ b/src/main/java/com/mjsec/lms/service/WeeklyAlertService.java
@@ -30,36 +30,36 @@ public class WeeklyAlertService {
         this.emailService = emailService;
     }
 
-    //주간 통합 과제 미제출자 체크 및 알림 발송
+    // 주간 통합 과제 미제출자 체크 및 알림 발송 (최근 1주일간 마감된 과제만)
     @Transactional(readOnly = true)
     public void checkAndSendWeeklyAssignmentReport() {
         log.info("Starting weekly assignment report generation...");
 
         LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneWeekAgo = now.minusWeeks(1);
 
-        // 마감된 모든 과제들 조회
-        List<Plan> expiredPlans = planRepository.findAll().stream()
-                .filter(assignment -> assignment.getEndDate() != null && assignment.getEndDate().isBefore(now))
-                .collect(Collectors.toList());
+        // 🔥 핵심 수정: hasAssignment=true이고 최근 1주일간 마감된 과제만 조회
+        List<Plan> recentlyExpiredAssignments = planRepository.findAssignmentsExpiredBetween(oneWeekAgo, now);
 
-        if (expiredPlans.isEmpty()) {
-            log.info("No expired assignments found. Weekly report will not be sent.");
+        if (recentlyExpiredAssignments.isEmpty()) {
+            log.info("No recently expired assignments found in the past week. Weekly report will not be sent.");
             return;
         }
 
-        log.info("Found {} expired assignments to process", expiredPlans.size());
+        log.info("Found {} recently expired assignments to process (past 7 days, assignments only)",
+                recentlyExpiredAssignments.size());
 
         // 스터디 그룹별로 과제들을 그룹핑하고 미제출 정보 생성
         Map<String, List<AssignmentNotSubmittedInfo>> reportData = new HashMap<>();
 
-        Map<StudyGroup, List<Plan>> assignmentsByStudyGroup = expiredPlans.stream()
+        Map<StudyGroup, List<Plan>> assignmentsByStudyGroup = recentlyExpiredAssignments.stream()
                 .collect(Collectors.groupingBy(Plan::getStudyGroup));
 
         for (Map.Entry<StudyGroup, List<Plan>> entry : assignmentsByStudyGroup.entrySet()) {
             StudyGroup studyGroup = entry.getKey();
-            List<Plan> plans = entry.getValue();
+            List<Plan> assignments = entry.getValue();
 
-            List<AssignmentNotSubmittedInfo> notSubmittedInfos = generateNotSubmittedInfos(studyGroup, plans);
+            List<AssignmentNotSubmittedInfo> notSubmittedInfos = generateNotSubmittedInfos(studyGroup, assignments);
 
             if (!notSubmittedInfos.isEmpty()) {
                 reportData.put(studyGroup.getName(), notSubmittedInfos);
@@ -67,19 +67,20 @@ public class WeeklyAlertService {
         }
 
         if (reportData.isEmpty()) {
-            log.info("All assignments have been submitted. Weekly report will not be sent.");
+            log.info("All recently expired assignments have been submitted. Weekly report will not be sent.");
             return;
         }
 
         // 이메일 발송
         emailService.sendWeeklyAssignmentReport(reportData, now);
-        log.info("Weekly assignment report sent successfully for {} study groups", reportData.size());
+        log.info("Weekly assignment report sent successfully for {} study groups with recently expired assignments",
+                reportData.size());
     }
 
-    //특정 스터디 그룹의 과제 미제출 정보 생성
-    private List<AssignmentNotSubmittedInfo> generateNotSubmittedInfos(StudyGroup studyGroup, List<Plan> plans) {
-        log.info("Generating report for study group: {} with {} assignments",
-                studyGroup.getName(), plans.size());
+    // 특정 스터디 그룹의 과제 미제출 정보 생성
+    private List<AssignmentNotSubmittedInfo> generateNotSubmittedInfos(StudyGroup studyGroup, List<Plan> assignments) {
+        log.info("Generating report for study group: {} with {} recently expired assignments",
+                studyGroup.getName(), assignments.size());
 
         // 해당 스터디 그룹의 모든 멘티 조회
         List<GroupMember> mentees = groupMemberRepository.findAll().stream()
@@ -89,11 +90,11 @@ public class WeeklyAlertService {
 
         List<AssignmentNotSubmittedInfo> result = new ArrayList<>();
 
-        // 각 과제별로 미제출자 확인
-        for (Plan plan : plans) {
+        // 각 과제별로 미제출자 확인 (hasAssignment=true인 것들만 처리됨)
+        for (Plan assignment : assignments) {
             // 과제를 제출한 사용자 ID 목록
             List<Long> submittedUserIds = submissionRepository
-                    .findAssignmentSubmissionsByPlanPlanId(plan.getPlanId())
+                    .findAssignmentSubmissionsByPlanPlanId(assignment.getPlanId())
                     .stream()
                     .map(submission -> submission.getSubmitter().getUserId())
                     .collect(Collectors.toList());
@@ -106,14 +107,14 @@ public class WeeklyAlertService {
 
             if (!notSubmittedStudents.isEmpty()) {
                 AssignmentNotSubmittedInfo info = AssignmentNotSubmittedInfo.builder()
-                        .planTitle(plan.getTitle())
-                        .endDate(plan.getEndDate())
+                        .planTitle(assignment.getTitle())
+                        .endDate(assignment.getEndDate())
                         .notSubmittedStudents(notSubmittedStudents)
                         .build();
 
                 result.add(info);
-                log.info("Assignment '{}' has {} not submitted students",
-                        plan.getTitle(), notSubmittedStudents.size());
+                log.info("Recently expired assignment '{}' has {} not submitted students",
+                        assignment.getTitle(), notSubmittedStudents.size());
             }
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,6 +80,11 @@ management:
     scheduledtasks:
       enabled: true
 
+alert:
+  assignment:
+    check-period-days: 7  # 최근 며칠간의 마감된 과제를 체크할지
+    max-assignments-per-email: 10 # 이메일당 최대 과제 수
+
 file:
   upload:
     path: uploads/


### PR DESCRIPTION
## 과제 미제출자 메일 보내기 로직 수정

hasAssignment 변수가 true인 과제만 + 해당 과제가 메일 보내는 시점을 기준으로 일주일 안에 있는 경우에만 보낼 수 있도록 수정함.

이전 로직의 경우, 메일을 그냥 과제 미제출자 모두 보냈었기에, 이게 계속 쌓이고 쌓이면 6개월치를 한번에 모두 보내는 상황까지 갈 수 있는 문제가 있어서 수정했습니다.

### 테스트 결과
그래서 테스트는 총 3개의 Plan 데이터를 만들었습니다.
1. 기간이 7월 29일부터 9월 5일까지인 과제
2. 기간이 7월 29일부터 9월 5일지만 과제가 아닌 계획
3. 기간이 7월 29일부터 8월 15일까지인 과제

이렇게 설정해두면 1번 하나만 출력이 되어야 합니다. (모두 과제는 제출하지 않았다고 가정)


<img width="803" height="602" alt="image" src="https://github.com/user-attachments/assets/4f2a3082-b16f-487c-9dc5-293c154fffac" />

잘 나오는 것을 확인할 수 있습니다 : )
