### PR TITLE
fix(delete-member): fixed delete-member feature for delete all entities with dependent relationships

### DIFF
--- a/src/main/java/com/mjsec/lms/repository/AttendanceRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/AttendanceRepository.java
@@ -58,4 +58,9 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     @Modifying
     @Query("DELETE FROM Attendance a WHERE a.studyGroup.creator = :user")
     void deleteByStudyGroupCreator(@Param("user") User user);
+
+    @Query("SELECT a.attendanceId FROM Attendance a " +
+            "WHERE a.user.userId = :userId " +
+            "AND a.studyGroup.studyId = :studyId")
+    List<Long> findIdsByUserIdAndStudyGroupId(@Param("userId") Long userId, @Param("studyId") Long studyId);
 }

--- a/src/main/java/com/mjsec/lms/repository/PlanCommentRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/PlanCommentRepository.java
@@ -30,4 +30,9 @@ public interface PlanCommentRepository extends JpaRepository<PlanComment, Long> 
     @Modifying
     @Query("DELETE FROM PlanComment p WHERE p.plan.studyGroup.creator = :user")
     void deleteByStudyGroupCreator(@Param("user") User user);
+
+    @Query("SELECT p.commentId FROM PlanComment p " +
+            "WHERE p.author.userId = :userId " +
+            "AND p.plan.studyGroup.studyId = :studyId")
+    List<Long> findIdsByUserIdAndStudyGroupId(@Param("userId") Long userId, @Param("studyId") Long studyId);
 }

--- a/src/main/java/com/mjsec/lms/repository/PlanRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/PlanRepository.java
@@ -50,9 +50,4 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     @Modifying
     @Query("DELETE FROM Plan p WHERE p.studyGroup.creator = :user")
     void deleteByStudyGroupCreator(@Param("user") User user);
-
-    @Query("SELECT p.planId FROM Plan p " +
-            "WHERE p.creator.userId = :userId " +
-            "AND p.studyGroup.studyId = :studyId")
-    List<Long> findIdsByCreatorIdAndStudyGroupId(@Param("userId") Long userId, @Param("studyId") Long studyId);
 }

--- a/src/main/java/com/mjsec/lms/repository/PlanRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/PlanRepository.java
@@ -50,4 +50,9 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     @Modifying
     @Query("DELETE FROM Plan p WHERE p.studyGroup.creator = :user")
     void deleteByStudyGroupCreator(@Param("user") User user);
+
+    @Query("SELECT p.planId FROM Plan p " +
+            "WHERE p.creator.userId = :userId " +
+            "AND p.studyGroup.studyId = :studyId")
+    List<Long> findIdsByCreatorIdAndStudyGroupId(@Param("userId") Long userId, @Param("studyId") Long studyId);
 }

--- a/src/main/java/com/mjsec/lms/repository/StudyActivityRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/StudyActivityRepository.java
@@ -30,4 +30,9 @@ public interface StudyActivityRepository extends JpaRepository<StudyActivity, Lo
     @Modifying
     @Query("DELETE FROM StudyActivity s WHERE s.studyGroup.creator = :user")
     void deleteByStudyGroupCreator(@Param("user") User user);
+
+    @Query("SELECT s.activityId FROM StudyActivity s " +
+            "WHERE s.creator.userId = :userId " +
+            "AND s.studyGroup.studyId = :studyId")
+    List<Long> findIdsByCreatorIdAndStudyGroupId(@Param("userId") Long userId, @Param("studyId") Long studyId);
 }

--- a/src/main/java/com/mjsec/lms/repository/SubmissionRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/SubmissionRepository.java
@@ -1,6 +1,7 @@
 package com.mjsec.lms.repository;
 
 import com.mjsec.lms.domain.AssignmentSubmission;
+import com.mjsec.lms.domain.StudyGroup;
 import com.mjsec.lms.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -31,4 +32,9 @@ public interface SubmissionRepository extends JpaRepository<AssignmentSubmission
     @Modifying
     @Query("DELETE FROM AssignmentSubmission a WHERE a.plan.studyGroup.creator = :user")
     void deleteByStudyGroupCreator(@Param("user") User user);
+
+    @Query("SELECT a.submissionId FROM AssignmentSubmission a " +
+            "WHERE a.submitter.userId = :userId " +
+            "AND a.plan.studyGroup.studyId = :studyId")
+    List<Long> findIdsByUserIdAndStudyGroupId(@Param("userId") Long userId, @Param("studyId") Long studyId);
 }

--- a/src/main/java/com/mjsec/lms/service/MentorService.java
+++ b/src/main/java/com/mjsec/lms/service/MentorService.java
@@ -4,10 +4,16 @@ import com.mjsec.lms.domain.GroupMember;
 import com.mjsec.lms.domain.StudyGroup;
 import com.mjsec.lms.domain.User;
 import com.mjsec.lms.exception.RestApiException;
+import com.mjsec.lms.repository.AttendanceRepository;
 import com.mjsec.lms.repository.GroupMemberRepository;
+import com.mjsec.lms.repository.PlanCommentRepository;
+import com.mjsec.lms.repository.PlanRepository;
+import com.mjsec.lms.repository.StudyActivityRepository;
 import com.mjsec.lms.repository.StudyGroupRepository;
+import com.mjsec.lms.repository.SubmissionRepository;
 import com.mjsec.lms.repository.UserRepository;
 import com.mjsec.lms.type.ErrorCode;
+import java.util.List;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,13 +25,25 @@ public class MentorService {
     private final UserRepository userRepository;
     private final StudyGroupRepository studyGroupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final SubmissionRepository submissionRepository;
+    private final PlanCommentRepository planCommentRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final StudyActivityRepository studyActivityRepository;
+    private final PlanRepository planRepository;
 
     public MentorService(UserRepository userRepository, StudyGroupRepository studyGroupRepository,
-                         GroupMemberRepository groupMemberRepository) {
+                         GroupMemberRepository groupMemberRepository, SubmissionRepository submissionRepository,
+                         PlanCommentRepository planCommentRepository, AttendanceRepository attendanceRepository,
+                         StudyActivityRepository studyActivityRepository, PlanRepository planRepository) {
 
         this.userRepository = userRepository;
         this.studyGroupRepository = studyGroupRepository;
         this.groupMemberRepository = groupMemberRepository;
+        this.submissionRepository = submissionRepository;
+        this.planCommentRepository = planCommentRepository;
+        this.attendanceRepository = attendanceRepository;
+        this.studyActivityRepository = studyActivityRepository;
+        this.planRepository = planRepository;
     }
 
     /**
@@ -75,7 +93,7 @@ public class MentorService {
     }
 
     /**
-     * 스터디 그룹에서 특정 멘티를 삭제시키는 메소드
+     * 스터디 그룹에서 특정 멘티를 삭제시키는 메소드 (그룹 멤버 엔티티와 연관이 있는 모든 엔티티 Soft Delete 처리)
      * @param currentStudentNumber 요청을 보낸 사용자의 학번
      * @param groupId 스터디 그룹의 Id
      * @param studentNumber 스터디 그룹 멘티의 학번
@@ -89,6 +107,34 @@ public class MentorService {
 
         GroupMember groupMember = groupMemberRepository.findByUserAndStudyGroup(mentee, studyGroup)
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_USER_NOT_FOUND));
+
+        Long userId = mentee.getUserId();
+        Long studyId = studyGroup.getStudyId();
+
+        List<Long> submissionIds = submissionRepository.findIdsByUserIdAndStudyGroupId(userId, studyId);
+        if (!submissionIds.isEmpty()) {
+            submissionRepository.deleteAllById(submissionIds);
+        }
+
+        List<Long> commentIds = planCommentRepository.findIdsByUserIdAndStudyGroupId(userId, studyId);
+        if (!commentIds.isEmpty()) {
+            planCommentRepository.deleteAllById(commentIds);
+        }
+
+        List<Long> attendanceIds = attendanceRepository.findIdsByUserIdAndStudyGroupId(userId, studyId);
+        if (!attendanceIds.isEmpty()) {
+            attendanceRepository.deleteAllById(attendanceIds);
+        }
+
+        List<Long> activityIds = studyActivityRepository.findIdsByCreatorIdAndStudyGroupId(userId, studyId);
+        if (!activityIds.isEmpty()) {
+            studyActivityRepository.deleteAllById(activityIds);
+        }
+
+        List<Long> planIds = planRepository.findIdsByCreatorIdAndStudyGroupId(userId, studyId);
+        if (!planIds.isEmpty()) {
+            planRepository.deleteAllById(planIds);
+        }
 
         groupMemberRepository.delete(groupMember);
     }

--- a/src/main/java/com/mjsec/lms/service/MentorService.java
+++ b/src/main/java/com/mjsec/lms/service/MentorService.java
@@ -131,11 +131,6 @@ public class MentorService {
             studyActivityRepository.deleteAllById(activityIds);
         }
 
-        List<Long> planIds = planRepository.findIdsByCreatorIdAndStudyGroupId(userId, studyId);
-        if (!planIds.isEmpty()) {
-            planRepository.deleteAllById(planIds);
-        }
-
         groupMemberRepository.delete(groupMember);
     }
 


### PR DESCRIPTION
## 변경사항
- 멘토 권한으로 멘티를 탈퇴시키는 기능을 수정하였습니다. 기존에는 멘티를 삭제시키는 기능 하나만 있었지만, 수정된 코드에서는 GroupMember 엔티티와 의존 관계를 갖는 모든 것들을 Soft Delete 시킵니다.
<img width="860" height="725" alt="스크린샷 2025-09-13 오전 1 45 14" src="https://github.com/user-attachments/assets/de887a85-f460-4a0a-b321-eee2bfbf5c82" />

순서는 다음과 같습니다. (가장 하위 종속성 -> 최종적으로 GroupMember 삭제)
1. Submission 삭제
2. PlanComment 삭제
3. Attendance 삭제
4. StudyActivity 삭제
5. GroupMember 삭제

물론 데이터가 많이 쌓이지 않은 상태에서 테스트를 해보면 delete_at이 정상적으로 들어가지만...몇 주동안 실서버에서 테스트를 해봐야 할 것 같습니다...

P.S 몇 주간 유찬이를 내 스터디에 임시에 넣어두고 경고도 줘보고 퇴출시키고 해봐야겠다 (테스트용)
<img width="353" height="334" alt="image" src="https://github.com/user-attachments/assets/b32d2f8f-cb28-41a4-aeb4-373c89809af2" />

LMS 완성(?)까지 얼마 남지 않았는데 다들 화이팅 입니다 :)