### PR TITLE
Feat: 이미지 조회 기능:

### DIFF
--- a/src/main/java/com/mjsec/lms/config/SecurityConfig.java
+++ b/src/main/java/com/mjsec/lms/config/SecurityConfig.java
@@ -99,6 +99,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/*", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/group/**").permitAll()
+                        .requestMatchers("/api/v1/image/**").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/v1/user/announcements/**").hasAnyRole("ADMIN", "USER")
                         .requestMatchers("/api/v1/user/password/**").permitAll()

--- a/src/main/java/com/mjsec/lms/controller/ImageController.java
+++ b/src/main/java/com/mjsec/lms/controller/ImageController.java
@@ -1,0 +1,103 @@
+package com.mjsec.lms.controller;
+
+import com.mjsec.lms.dto.ImageResponse;
+import com.mjsec.lms.service.ImageService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/image")
+@Slf4j
+public class ImageController {
+
+    private final ImageService imageService;
+
+    public ImageController(ImageService imageService) {
+        this.imageService = imageService;
+    }
+
+    /**
+     * 이미지 파일 서빙 API
+     * 인증된 사용자만 접근 가능하며, 스터디 그룹 멤버십 확인 후 이미지 반환
+     *
+     * @param filename 이미지 파일명 (UUID + 확장자 형태)
+     * @param authentication 인증 정보
+     * @return 이미지 파일 리소스
+     */
+    @GetMapping("/{filename}")
+    public ResponseEntity<Resource> getImage(
+            @PathVariable String filename,
+            Authentication authentication) {
+
+        log.info("Image request received for filename: {}", filename);
+
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        // 이미지 파일과 메타데이터 조회
+        ImageResponse imageResponse = imageService.getImage(filename, currentUserStudentNumber);
+
+        // HTTP 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(imageResponse.getMediaType());
+        headers.setContentLength(imageResponse.getContentLength());
+
+        // 브라우저 캐싱 설정 (1시간)
+        headers.setCacheControl("public, max-age=3600");
+
+        // 파일명 설정 (다운로드 시 사용될 이름)
+        headers.setContentDisposition(
+                org.springframework.http.ContentDisposition.inline()
+                        .filename(imageResponse.getOriginalFilename())
+                        .build()
+        );
+
+        log.info("Image served successfully: {}, size: {} bytes",
+                filename, imageResponse.getContentLength());
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(imageResponse.getResource());
+    }
+
+    /**
+     * 프로필 이미지 서빙 API (별도 처리)
+     * 사용자 프로필 이미지는 더 관대한 접근 권한 적용
+     *
+     * @param filename 프로필 이미지 파일명
+     * @param authentication 인증 정보
+     * @return 프로필 이미지 파일 리소스
+     */
+    @GetMapping("/profile/{filename}")
+    public ResponseEntity<Resource> getProfileImage(
+            @PathVariable String filename,
+            Authentication authentication) {
+
+        log.info("Profile image request received for filename: {}", filename);
+
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        // 프로필 이미지는 더 관대한 권한으로 처리
+        ImageResponse imageResponse = imageService.getProfileImage(filename, currentUserStudentNumber);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(imageResponse.getMediaType());
+        headers.setContentLength(imageResponse.getContentLength());
+        headers.setCacheControl("public, max-age=7200"); // 프로필 이미지는 2시간 캐싱
+        headers.setContentDisposition(
+                org.springframework.http.ContentDisposition.inline()
+                        .filename(imageResponse.getOriginalFilename())
+                        .build()
+        );
+
+        log.info("Profile image served successfully: {}", filename);
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(imageResponse.getResource());
+    }
+}

--- a/src/main/java/com/mjsec/lms/dto/ImageResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/ImageResponse.java
@@ -1,0 +1,15 @@
+package com.mjsec.lms.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+
+@Getter
+@Builder
+public class ImageResponse {
+    private Resource resource;
+    private MediaType mediaType;
+    private long contentLength;
+    private String originalFilename;
+}

--- a/src/main/java/com/mjsec/lms/service/ImageService.java
+++ b/src/main/java/com/mjsec/lms/service/ImageService.java
@@ -1,0 +1,215 @@
+package com.mjsec.lms.service;
+
+import com.mjsec.lms.domain.GroupMember;
+import com.mjsec.lms.domain.StudyActivity;
+import com.mjsec.lms.domain.StudyGroup;
+import com.mjsec.lms.domain.User;
+import com.mjsec.lms.dto.ImageResponse;
+import com.mjsec.lms.exception.RestApiException;
+import com.mjsec.lms.repository.GroupMemberRepository;
+import com.mjsec.lms.repository.StudyActivityRepository;
+import com.mjsec.lms.type.ErrorCode;
+import com.mjsec.lms.util.ValidationUtils;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class ImageService {
+
+    @Value("${file.upload.path:uploads/}")
+    private String uploadPath;
+
+    private final StudyActivityRepository studyActivityRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final ValidationUtils validationUtils;
+
+    // 지원하는 이미지 파일 확장자와 MIME 타입 매핑
+    private static final Map<String, MediaType> SUPPORTED_IMAGE_TYPES = new HashMap<>();
+
+    static {
+        SUPPORTED_IMAGE_TYPES.put("jpg", MediaType.IMAGE_JPEG);
+        SUPPORTED_IMAGE_TYPES.put("jpeg", MediaType.IMAGE_JPEG);
+        SUPPORTED_IMAGE_TYPES.put("png", MediaType.IMAGE_PNG);
+        SUPPORTED_IMAGE_TYPES.put("gif", MediaType.IMAGE_GIF);
+        SUPPORTED_IMAGE_TYPES.put("webp", MediaType.valueOf("image/webp"));
+    }
+
+    public ImageService(StudyActivityRepository studyActivityRepository,
+                        GroupMemberRepository groupMemberRepository,
+                        ValidationUtils validationUtils) {
+        this.studyActivityRepository = studyActivityRepository;
+        this.groupMemberRepository = groupMemberRepository;
+        this.validationUtils = validationUtils;
+    }
+
+    /**
+     * 스터디 활동 이미지 조회 (권한 검증 포함)
+     * 해당 스터디 그룹의 멤버만 이미지 접근 가능
+     *
+     * @param filename 이미지 파일명
+     * @param currentUserStudentNumber 현재 사용자 학번
+     * @return 이미지 응답 객체
+     */
+    @Transactional(readOnly = true)
+    public ImageResponse getImage(String filename, Long currentUserStudentNumber) {
+        log.info("Getting image: {} for user: {}", filename, currentUserStudentNumber);
+
+        // 사용자 검증
+        User currentUser = validationUtils.validateUser(currentUserStudentNumber);
+
+        // 파일명으로 스터디 활동 찾기
+        StudyActivity studyActivity = findStudyActivityByImageUrl(filename);
+
+        if (studyActivity != null) {
+            // 스터디 활동 이미지인 경우 - 해당 그룹 멤버만 접근 가능
+            StudyGroup studyGroup = studyActivity.getStudyGroup();
+            validationUtils.validateGroupMembership(currentUser, studyGroup);
+
+            log.info("Access granted to study activity image for group: {} by user: {}",
+                    studyGroup.getStudyId(), currentUserStudentNumber);
+        } else {
+            // 스터디 그룹 이미지인지 확인 (StudyGroup의 studyImage)
+            if (!isStudyGroupImageAccessible(filename, currentUser)) {
+                log.warn("Unauthorized image access attempt: {} by user: {}", filename, currentUserStudentNumber);
+                throw new RestApiException(ErrorCode.UNAUTHORIZED_IMAGE_ACCESS);
+            }
+        }
+
+        // 파일 시스템에서 이미지 로드
+        return loadImageFromFileSystem(filename);
+    }
+
+    /**
+     * 프로필 이미지 조회 (더 관대한 권한)
+     * 인증된 사용자는 모든 프로필 이미지 접근 가능
+     *
+     * @param filename 프로필 이미지 파일명
+     * @param currentUserStudentNumber 현재 사용자 학번
+     * @return 이미지 응답 객체
+     */
+    @Transactional(readOnly = true)
+    public ImageResponse getProfileImage(String filename, Long currentUserStudentNumber) {
+        log.info("Getting profile image: {} for user: {}", filename, currentUserStudentNumber);
+
+        // 기본 사용자 검증만 수행 (인증된 사용자면 모든 프로필 이미지 접근 가능)
+        validationUtils.validateUser(currentUserStudentNumber);
+
+        return loadImageFromFileSystem(filename);
+    }
+
+    /**
+     * 파일명으로 스터디 활동 찾기
+     */
+    private StudyActivity findStudyActivityByImageUrl(String filename) {
+        String imageUrl = "/uploads/" + filename;
+        return studyActivityRepository.findAll()
+                .stream()
+                .filter(activity -> imageUrl.equals(activity.getImageUrl()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * 스터디 그룹 이미지에 대한 접근 권한 확인
+     * 해당 그룹의 멤버인지 확인
+     */
+    private boolean isStudyGroupImageAccessible(String filename, User currentUser) {
+        String imageUrl = "/uploads/" + filename;
+
+        // GroupMember 테이블에서 해당 사용자가 속한 그룹들 조회
+        List<GroupMember> userGroups = groupMemberRepository.findByUserIdWithStudyGroup(currentUser.getUserId());
+
+        // 그 중에서 해당 이미지 URL을 가진 스터디 그룹이 있는지 확인
+        return userGroups.stream()
+                .anyMatch(groupMember ->
+                        imageUrl.equals(groupMember.getStudyGroup().getStudyImage()));
+    }
+    /**
+     * 파일 시스템에서 실제 이미지 파일을 로드
+     */
+    private ImageResponse loadImageFromFileSystem(String filename) {
+        try {
+            // 보안: 경로 순회 공격 방지
+            if (filename.contains("..") || filename.contains("/") || filename.contains("\\")) {
+                log.warn("Potential path traversal attack detected: {}", filename);
+                throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
+            }
+
+            // 파일 경로 구성
+            Path filePath = Paths.get(uploadPath).resolve(filename).normalize();
+
+            // 업로드 디렉토리 밖으로 벗어나는지 확인
+            if (!filePath.startsWith(Paths.get(uploadPath).normalize())) {
+                log.warn("Path traversal attempt detected: {}", filename);
+                throw new RestApiException(ErrorCode.INVALID_FILE_PATH);
+            }
+
+            // 파일 존재 여부 확인
+            if (!Files.exists(filePath)) {
+                log.error("Image file not found: {}", filename);
+                throw new RestApiException(ErrorCode.IMAGE_NOT_FOUND);
+            }
+
+            // 파일 확장자로 MIME 타입 결정
+            String extension = getFileExtension(filename).toLowerCase();
+            MediaType mediaType = SUPPORTED_IMAGE_TYPES.get(extension);
+
+            if (mediaType == null) {
+                log.error("Unsupported image type: {}", extension);
+                throw new RestApiException(ErrorCode.UNSUPPORTED_IMAGE_TYPE);
+            }
+
+            // 파일 리소스 생성
+            Resource resource = new FileSystemResource(filePath);
+
+            if (!resource.exists() || !resource.isReadable()) {
+                log.error("Image file not readable: {}", filename);
+                throw new RestApiException(ErrorCode.IMAGE_NOT_READABLE);
+            }
+
+            // 파일 크기 조회
+            long contentLength = Files.size(filePath);
+
+            log.info("Image loaded successfully: {}, size: {} bytes", filename, contentLength);
+
+            return ImageResponse.builder()
+                    .resource(resource)
+                    .mediaType(mediaType)
+                    .contentLength(contentLength)
+                    .originalFilename(filename)
+                    .build();
+
+        } catch (IOException e) {
+            log.error("Failed to load image: {}", filename, e);
+            throw new RestApiException(ErrorCode.IMAGE_LOAD_FAILED);
+        }
+    }
+
+    /**
+     * 파일명에서 확장자 추출
+     */
+    private String getFileExtension(String filename) {
+        int lastDotIndex = filename.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            return "";
+        }
+        return filename.substring(lastDotIndex + 1);
+    }
+
+}

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -107,6 +107,13 @@ public enum ErrorCode {
     EMPTY_FILE(HttpStatus.BAD_REQUEST, "빈 파일입니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 너무 큽니다."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 형식입니다."),
+    UNAUTHORIZED_IMAGE_ACCESS(HttpStatus.FORBIDDEN, "해당 이미지에 접근할 권한이 없습니다."),
+    INVALID_FILE_NAME(HttpStatus.BAD_REQUEST,  "유효하지 않은 파일명입니다."),
+    INVALID_FILE_PATH(HttpStatus.BAD_REQUEST,  "유효하지 않은 파일 경로입니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지 파일을 찾을 수 없습니다."),
+    UNSUPPORTED_IMAGE_TYPE(HttpStatus.BAD_REQUEST,  "지원하지 않는 이미지 파일 형식입니다."),
+    IMAGE_NOT_READABLE(HttpStatus.INTERNAL_SERVER_ERROR,  "이미지 파일을 읽을 수 없습니다."),
+    IMAGE_LOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 로딩 중 오류가 발생했습니다.")
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
### 이미지 조회 기능 추가

**로그인한 상태에서 해당 스터디 그룹에 속할 경우 이미지 조회되도록 일단 설정함.**

기본 사용 방식은 **/api/v1/image/파일명.확장자 버전임.**
예: `/api/v1/image/1a947ab4-7403-424c-8566-f864bbcbd6f.jpg`

테스트

이미지 없거나 권한 없을 경우
<img width="632" height="502" alt="image" src="https://github.com/user-attachments/assets/1dd6f285-64f1-4c74-99d8-21a8e8537764" />

이미지 정상 조회 성공

<img width="920" height="790" alt="image" src="https://github.com/user-attachments/assets/e6beb2be-85e0-4f9f-82a9-bf85904961d3" />

스터디 멤버가 아닌 경우

<img width="719" height="524" alt="image" src="https://github.com/user-attachments/assets/97dbac7c-6fb5-4756-923d-be11ae61d4cb" />

급해서 일단 막 올렸고 코드가 정상이 아닐 수도 있습니다.
내일 차근차근 다시 보면서 수정하겠습니다
일단 돌아가게만 했음


**건하 선생님 죄송합니다 ㅠㅠㅠㅠㅠ**
