### PR TITLE
feat(user-page-update): add user-page-update feature

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/UserController.java
+++ b/src/main/java/com/mjsec/lms/controller/UserController.java
@@ -3,12 +3,14 @@ package com.mjsec.lms.controller;
 import com.mjsec.lms.dto.PasswordUpdateDto;
 import com.mjsec.lms.dto.SuccessResponse;
 import com.mjsec.lms.dto.UserResponse;
+import com.mjsec.lms.dto.UserUpdateDto;
 import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.service.AuthCodeService;
 import com.mjsec.lms.service.EmailService;
 import com.mjsec.lms.service.UserService;
 import com.mjsec.lms.type.ErrorCode;
 import com.mjsec.lms.type.ResponseMessage;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,8 +21,11 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/user")
 public class UserController {
@@ -29,17 +34,9 @@ public class UserController {
     private final AuthCodeService authCodeService;
     private final EmailService emailService;
 
-    UserController(UserService userService, AuthCodeService authCodeService, EmailService emailService) {
-
-        this.userService = userService;
-        this.authCodeService = authCodeService;
-        this.emailService = emailService;
-    }
-
     @GetMapping("/user-page")
     public ResponseEntity<SuccessResponse<UserResponse>> getUserPage(Authentication authentication){
 
-        // JwtFilter에서 설정한 studentNumber를 가져옴
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();
 
         UserResponse userResponse = userService.getUserPage(currentUserStudentNumber);
@@ -48,6 +45,23 @@ public class UserController {
                 SuccessResponse.of(
                         ResponseMessage.USER_GET_PAGE_SUCCESS,
                         userResponse
+                )
+        );
+    }
+
+    @PutMapping("/user-page")
+    public ResponseEntity<SuccessResponse<Void>> updateUser(
+            Authentication authentication,
+            @RequestPart(required = false) MultipartFile profileImage,
+            @Valid @RequestPart UserUpdateDto userUpdateDto
+    ) {
+
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+        userService.updateUser(currentUserStudentNumber, profileImage, userUpdateDto);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.UPDATE_USER_SUCCESS
                 )
         );
     }

--- a/src/main/java/com/mjsec/lms/controller/UserController.java
+++ b/src/main/java/com/mjsec/lms/controller/UserController.java
@@ -53,7 +53,7 @@ public class UserController {
     public ResponseEntity<SuccessResponse<Void>> updateUser(
             Authentication authentication,
             @RequestPart(required = false) MultipartFile profileImage,
-            @Valid @RequestPart UserUpdateDto userUpdateDto
+            @Valid @RequestPart(required = false) UserUpdateDto userUpdateDto
     ) {
 
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();

--- a/src/main/java/com/mjsec/lms/dto/UserUpdateDto.java
+++ b/src/main/java/com/mjsec/lms/dto/UserUpdateDto.java
@@ -1,0 +1,20 @@
+package com.mjsec.lms.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UserUpdateDto {
+
+    @Pattern(regexp = "^[가-힣]+$", message = "사용자 이름은 한글로만 이루어져야 합니다.")
+    private String name;
+
+    @Email(message = "유효한 이메일 주소 형식이어야 합니다.")
+    private String email;
+
+    @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호는 010-xxxx-xxxx 형식이어야 합니다.")
+    private String phoneNumber;
+}

--- a/src/main/java/com/mjsec/lms/service/UserService.java
+++ b/src/main/java/com/mjsec/lms/service/UserService.java
@@ -11,7 +11,6 @@ import com.mjsec.lms.repository.UserRepository;
 import com.mjsec.lms.type.ErrorCode;
 import com.mjsec.lms.util.ValidationUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/mjsec/lms/service/UserService.java
+++ b/src/main/java/com/mjsec/lms/service/UserService.java
@@ -4,17 +4,20 @@ import com.mjsec.lms.domain.GroupMember;
 import com.mjsec.lms.domain.User;
 import com.mjsec.lms.dto.StudyGroupSummaryDto;
 import com.mjsec.lms.dto.UserResponse;
+import com.mjsec.lms.dto.UserUpdateDto;
 import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.repository.GroupMemberRepository;
 import com.mjsec.lms.repository.UserRepository;
 import com.mjsec.lms.type.ErrorCode;
 import com.mjsec.lms.util.ValidationUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Slf4j
@@ -24,15 +27,17 @@ public class UserService {
     private final GroupMemberRepository groupMemberRepository;
     private final ValidationUtils validationUtils;
     private final PasswordEncoder passwordEncoder;
+    private final FileService fileService;
 
     public UserService(UserRepository userRepository,
                        GroupMemberRepository groupMemberRepository,
-                       ValidationUtils validationUtils, PasswordEncoder passwordEncoder) {
+                       ValidationUtils validationUtils, PasswordEncoder passwordEncoder, FileService fileService) {
 
         this.userRepository = userRepository;
         this.groupMemberRepository = groupMemberRepository;
         this.validationUtils = validationUtils;
         this.passwordEncoder = passwordEncoder;
+        this.fileService = fileService;
     }
 
     // 유저 페이지 조회
@@ -111,6 +116,39 @@ public class UserService {
                 .orElseThrow(() -> new RestApiException(ErrorCode.NOT_REGISTERED_EMAIL));
 
         user.setPassword(passwordEncoder.encode(password));
+        userRepository.save(user);
+    }
+
+    /**
+     * 유저 정보를 수정하는 메소드 (프로필 이미지, 이름, 이메일, 전화번호)
+     * @param currentStudentNumber 유저의 학번
+     * @param profileImage 프로필 이미지
+     * @param userUpdateDto 이름, 이메일, 전화번호 정보를 담는 Dto
+     */
+    public void updateUser(Long currentStudentNumber, MultipartFile profileImage, UserUpdateDto userUpdateDto) {
+
+        User user = userRepository.findByStudentNumber(currentStudentNumber)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+        if(profileImage != null && !profileImage.isEmpty()) {
+            String imgUrl = fileService.uploadImage(profileImage);
+            user.setProfileImage(imgUrl);
+        }
+
+        if(userUpdateDto != null) {
+            if(userUpdateDto.getName() != null && !userUpdateDto.getName().trim().isEmpty()) {
+                user.setName(userUpdateDto.getName());
+            }
+
+            if(userUpdateDto.getEmail() != null && !userUpdateDto.getEmail().trim().isEmpty()) {
+                user.setEmail(userUpdateDto.getEmail());
+            }
+
+            if(userUpdateDto.getPhoneNumber() != null && !userUpdateDto.getPhoneNumber().trim().isEmpty()) {
+                user.setPhoneNumber(userUpdateDto.getPhoneNumber());
+            }
+        }
+
         userRepository.save(user);
     }
 }

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -29,6 +29,7 @@ public enum ResponseMessage {
     SEND_CODE_SUCCESS("인증 코드 전송 성공"),
     EMAIL_VERIFICATION_SUCCESS("이메일 인증 성공"),
     UPDATE_PASSWORD_SUCCESS("비밀번호 변경 성공"),
+    UPDATE_USER_SUCCESS("유저 정보 수정 성공"),
 
     // 과제
     ASSIGNMENT_SUBMIT_SUCCESS("과제 제출 성공"),


### PR DESCRIPTION
## 변경사항

- 유저의 정보를 수정하는 API가 추가되었습니다. (권한이 필요하지만, USER / ADMIN 상관없음)
<img width="703" height="95" alt="스크린샷 2025-09-15 오후 2 27 47" src="https://github.com/user-attachments/assets/1115c569-b390-4684-823d-2088c2ea341d" />

PUT 메소드를 사용하여 요청을 보내며, 기존 Study Group 정보 수정 API와 동일하게 Request Part 2개를 필요로 합니다.
하나는 profileImage, 하나는 UserUpdateDto 입니다. (정보 수정 기능이기 때문에 어느 쪽이든 null값을 가질 수 있습니다.)
<img width="712" height="239" alt="스크린샷 2025-09-15 오후 2 30 17" src="https://github.com/user-attachments/assets/81de371a-f35d-4623-9d15-e277c3081455" />

## 테스트

1. 먼저 아무 계정으로 로그인을 합니다.
<img width="1260" height="946" alt="스크린샷 2025-09-15 오후 1 42 56" src="https://github.com/user-attachments/assets/279ea46e-f402-41b9-9a86-89044bb2f9ee" />

2. 기존 유저 데이터를 확인합니다.
<img width="1470" height="293" alt="스크린샷 2025-09-15 오후 1 48 17" src="https://github.com/user-attachments/assets/7281837e-97a3-4cbc-acfd-30b0ee736bdd" />

제가 테스트에 사용했던 계정은 첫번째 줄에 있는 계정입니다. (name은 관리자, 전화번호는 010-3727-3727 ...)

3. /api/v1/user/user-page 로 PUT 요청을 날려봅시다.
<img width="1260" height="946" alt="스크린샷 2025-09-15 오후 2 22 08" src="https://github.com/user-attachments/assets/c3fa926f-522f-4610-9f26-3558724fbc00" />

4. 바뀐 유저 데이터를 확인합니다.
<img width="1470" height="920" alt="스크린샷 2025-09-15 오후 2 22 26" src="https://github.com/user-attachments/assets/aa2871de-898e-4f0d-8efb-e661c474ca9b" />
<img width="1470" height="920" alt="스크린샷 2025-09-15 오후 2 22 38" src="https://github.com/user-attachments/assets/51ee4e1f-bf87-4363-bc2e-40af09f82e9b" />


