### PR TITLE
feat(get-all-group-info): add getting all groups info feature

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/AdminController.java
+++ b/src/main/java/com/mjsec/lms/controller/AdminController.java
@@ -2,7 +2,9 @@ package com.mjsec.lms.controller;
 
 import com.mjsec.lms.dto.PendingUserDto;
 import com.mjsec.lms.dto.StudyGroupDto.StudyGroupRequestDto;
+import com.mjsec.lms.dto.StudyGroupDto.StudyGroupResponseDto;
 import com.mjsec.lms.dto.StudyGroupDto.StudyGroupUpdateDto;
+import com.mjsec.lms.dto.StudyGroupSummaryDto;
 import com.mjsec.lms.dto.SuccessResponse;
 import com.mjsec.lms.dto.UserAdminResponseDto;
 import com.mjsec.lms.service.AdminService;
@@ -63,6 +65,19 @@ public class AdminController {
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessResponse.of(
                         ResponseMessage.REFUSE_REGISTER_SUCCESS
+                )
+        );
+    }
+
+    @GetMapping("/group/all")
+    public ResponseEntity<SuccessResponse<List<StudyGroupSummaryDto>>> getAllGroups() {
+
+        List<StudyGroupSummaryDto> groups = adminService.getAllGroups();
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.GET_ALL_GROUPS_SUCCESS,
+                        groups
                 )
         );
     }

--- a/src/main/java/com/mjsec/lms/service/AdminService.java
+++ b/src/main/java/com/mjsec/lms/service/AdminService.java
@@ -5,7 +5,9 @@ import com.mjsec.lms.domain.StudyGroup;
 import com.mjsec.lms.domain.User;
 import com.mjsec.lms.dto.PendingUserDto;
 import com.mjsec.lms.dto.StudyGroupDto.StudyGroupRequestDto;
+import com.mjsec.lms.dto.StudyGroupDto.StudyGroupResponseDto;
 import com.mjsec.lms.dto.StudyGroupDto.StudyGroupUpdateDto;
+import com.mjsec.lms.dto.StudyGroupSummaryDto;
 import com.mjsec.lms.dto.UserAdminResponseDto;
 import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.repository.AnnouncementRepository;
@@ -18,10 +20,12 @@ import com.mjsec.lms.repository.StudyActivityRepository;
 import com.mjsec.lms.repository.StudyGroupRepository;
 import com.mjsec.lms.repository.SubmissionRepository;
 import com.mjsec.lms.repository.UserRepository;
+import com.mjsec.lms.type.Category;
 import com.mjsec.lms.type.ErrorCode;
 import com.mjsec.lms.type.UserRole;
 import jakarta.transaction.Transactional;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -152,6 +156,30 @@ public class AdminService {
 
         pendingUserRepository.delete(pendingUser);
         log.info("Deleted pending user for registration refusal: {}", studentNumber);
+    }
+
+    /**
+     * 모든 스터디 그룹의 정보를 반환하는 메소드 (study group Id, 이름, 카테고리, 스터디 그룹 대표 이미지만 반환)
+     * @return List<StudyGroupSummaryDto>
+     */
+    public List<StudyGroupSummaryDto> getAllGroups() {
+
+        log.info("Getting All Groups Info");
+
+        List<StudyGroupSummaryDto> groups = studyGroupRepository.findAll().stream()
+                .map(studyGroup -> {
+                    return StudyGroupSummaryDto.builder()
+                            .studyGroupId(studyGroup.getStudyId())
+                            .name(studyGroup.getName())
+                            .category(studyGroup.getCategory())
+                            .studyImage(studyGroup.getStudyImage())
+                            .build();
+                })
+                .toList();
+
+        log.info("{} Groups returned", groups.size());
+
+        return groups;
     }
 
     /**

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -80,6 +80,7 @@ public enum ResponseMessage {
     // 스터디그룹 관련
     STUDY_MEMBER_GET_SUCCESS("스터디 전체 멤버 반환 성공"),
     STUDY_MENTEE_GET_SUCCESS("스터디 멘티 멤버 반환 성공"),
+    GET_ALL_GROUPS_SUCCESS("전체 스터디 그룹 정보 조회 성공")
     ;
     private final String message;
 }


### PR DESCRIPTION
## 변경사항

- 모든 스터디 그룹의 정보를 반환하는 API가 추가되었습니다.
<img width="699" height="412" alt="스크린샷 2025-09-15 오후 3 33 44" src="https://github.com/user-attachments/assets/bb1d468b-06ca-4be4-baff-705487a9f1c8" />

GET메소드를 통해 호출하며, Authorization 토큰만 요구하는 간단한 API 입니다.
List<StudyGroupSummaryDto>를 반환합니다.

참고로 StudyGroupSummaryDto 정보는 다음과 같습니다.
<img width="303" height="235" alt="스크린샷 2025-09-15 오후 3 36 00" src="https://github.com/user-attachments/assets/c3a677d4-9779-4f85-80d4-cbde7edbc890" />


## 테스트
<img width="1260" height="946" alt="스크린샷 2025-09-15 오후 3 34 27" src="https://github.com/user-attachments/assets/056656de-c994-473f-875a-b3d380af8d4b" />

---

<img width="300" height="168" alt="image" src="https://github.com/user-attachments/assets/e67cb80a-26ba-4ab4-a846-7d0bed44feab" />

