### PR TITLE
fix(create-announcement): fixed request matchers for 403 error

### DIFF
--- a/src/main/java/com/mjsec/lms/config/SecurityConfig.java
+++ b/src/main/java/com/mjsec/lms/config/SecurityConfig.java
@@ -101,6 +101,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/group/**").permitAll()
                         .requestMatchers("/api/v1/image/**").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/v1/user/create-announcement").hasAnyRole("ADMIN", "USER")
                         .requestMatchers("/api/v1/user/announcements/**").hasAnyRole("ADMIN", "USER")
                         .requestMatchers("/api/v1/user/password/**").permitAll()
                         .requestMatchers("/api/v1/user/user-page").hasAnyRole("ADMIN", "USER")


### PR DESCRIPTION
## 변경사항

- 접근 관리를 위해 security config의 request matchers를 수정하였습니다.

<img width="874" height="26" alt="스크린샷 2025-09-15 오후 4 01 05" src="https://github.com/user-attachments/assets/dace9654-1812-493e-ab50-287ef8b0705d" />
