### PR TITLE
fix(create-group): add putting mentor as group member

### DIFF
--- a/src/main/java/com/mjsec/lms/domain/StudyGroup.java
+++ b/src/main/java/com/mjsec/lms/domain/StudyGroup.java
@@ -1,6 +1,6 @@
 package com.mjsec.lms.domain;
 
-import com.mjsec.lms.type.studyStatus;
+import com.mjsec.lms.type.StudyStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -38,7 +38,7 @@ public class StudyGroup extends BaseEntity {
     @Column(name = "study_image", columnDefinition = "TEXT")
     private String studyImage;
 
-    private studyStatus status = studyStatus.ACTIVE;
+    private StudyStatus status = StudyStatus.ACTIVE;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "created_by_id")

--- a/src/main/java/com/mjsec/lms/domain/StudyGroup.java
+++ b/src/main/java/com/mjsec/lms/domain/StudyGroup.java
@@ -38,7 +38,6 @@ public class StudyGroup extends BaseEntity {
     @Column(name = "study_image", columnDefinition = "TEXT")
     private String studyImage;
 
-    //스터디 그룹 진행중, 종료 여부 <민수햄 보면 삭제좀>
     private studyStatus status = studyStatus.ACTIVE;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/mjsec/lms/dto/StudyMemberWarnResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/StudyMemberWarnResponse.java
@@ -1,6 +1,5 @@
 package com.mjsec.lms.dto;
 
-import com.mjsec.lms.type.studyStatus;
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/mjsec/lms/service/AdminService.java
+++ b/src/main/java/com/mjsec/lms/service/AdminService.java
@@ -1,5 +1,6 @@
 package com.mjsec.lms.service;
 
+import com.mjsec.lms.domain.GroupMember;
 import com.mjsec.lms.domain.PendingUser;
 import com.mjsec.lms.domain.StudyGroup;
 import com.mjsec.lms.domain.User;
@@ -22,6 +23,7 @@ import com.mjsec.lms.repository.SubmissionRepository;
 import com.mjsec.lms.repository.UserRepository;
 import com.mjsec.lms.type.Category;
 import com.mjsec.lms.type.ErrorCode;
+import com.mjsec.lms.type.GroupMemberRole;
 import com.mjsec.lms.type.UserRole;
 import jakarta.transaction.Transactional;
 import java.util.List;
@@ -186,6 +188,7 @@ public class AdminService {
      * 스터디 그룹을 생성하는 메소드
      * @param requestDto 스터디 그룹명, 스터디 소개, 스터디 타입, 멘토 학번
      */
+    @Transactional
     public void createGroup(StudyGroupRequestDto requestDto) {
 
         User mentor = userRepository.findByStudentNumber(requestDto.getMentorStudentNumber())
@@ -203,6 +206,14 @@ public class AdminService {
                 .build();
 
         studyGroupRepository.save(studyGroup);
+
+        GroupMember groupMentor = GroupMember.builder()
+                .role(GroupMemberRole.MENTOR)
+                .user(mentor)
+                .studyGroup(studyGroup)
+                .build();
+
+        groupMemberRepository.save(groupMentor);
     }
 
     /**

--- a/src/main/java/com/mjsec/lms/type/StudyStatus.java
+++ b/src/main/java/com/mjsec/lms/type/StudyStatus.java
@@ -1,6 +1,6 @@
 package com.mjsec.lms.type;
 
-public enum studyStatus {
+public enum StudyStatus {
     ACTIVE,
     INACTIVE,
 }


### PR DESCRIPTION
## 변경사항
- 스터디 그룹 생성시 멘토 Id를 저장하는 로직만 있었지만, 멘토를 group member에 추가하는 기능이 추가 되었습니다.
<img width="752" height="395" alt="스크린샷 2025-09-16 오후 10 31 26" src="https://github.com/user-attachments/assets/79d9cb7a-549d-4d60-ae44-82ed0132354c" />


P.S 스터디 그룹에서 studyActive를 넣은건 봤는데... 대문자 시작이 아니라 네이밍 refactor 했습니다~!