### PR TITLE
feat(get-mentee-groups): add get-mentee-groups feature

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/StudyGroupController.java
+++ b/src/main/java/com/mjsec/lms/controller/StudyGroupController.java
@@ -210,4 +210,18 @@ public class StudyGroupController {
                 )
         );
     }
+
+    @GetMapping("/all")
+    public ResponseEntity<SuccessResponse<List<MenteeStudyGroupDto>>> getAllGroups(Authentication authentication) {
+
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+        List<MenteeStudyGroupDto> groups = studyGroupService.getAllGroups(currentUserStudentNumber);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.GET_ALL_MENTEE_GROUPS_SUCCESS,
+                        groups
+                )
+        );
+    }
 }

--- a/src/main/java/com/mjsec/lms/dto/MenteeStudyGroupDto.java
+++ b/src/main/java/com/mjsec/lms/dto/MenteeStudyGroupDto.java
@@ -1,0 +1,20 @@
+package com.mjsec.lms.dto;
+
+import com.mjsec.lms.type.StudyStatus;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MenteeStudyGroupDto {
+
+    private Long studyGroupId;
+
+    private String name;
+
+    private String category;
+
+    private String studyImage;
+
+    private StudyStatus status;
+}

--- a/src/main/java/com/mjsec/lms/repository/GroupMemberRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/GroupMemberRepository.java
@@ -39,4 +39,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     @Modifying
     @Query("DELETE FROM GroupMember g WHERE g.studyGroup.creator = :user")
     void deleteByStudyGroupCreator(@Param("user") User user);
+
+    @Query("SELECT gm FROM GroupMember gm JOIN FETCH gm.studyGroup WHERE gm.user = :user AND gm.role = :role")
+    List<GroupMember> findByUserAndRoleWithStudyGroup(@Param("user") User user, @Param("role") GroupMemberRole role);
 }

--- a/src/main/java/com/mjsec/lms/service/StudyGroupService.java
+++ b/src/main/java/com/mjsec/lms/service/StudyGroupService.java
@@ -2,9 +2,12 @@ package com.mjsec.lms.service;
 
 import com.mjsec.lms.domain.*;
 import com.mjsec.lms.dto.*;
+import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.repository.*;
+import com.mjsec.lms.type.ErrorCode;
 import com.mjsec.lms.type.GroupMemberRole;
 import com.mjsec.lms.util.ValidationUtils;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -424,5 +427,25 @@ public class StudyGroupService {
                 .ProfileImage(groupMember.getUser().getProfileImage())
                 .warn(groupMember.getWarn())
                 .build();
+    }
+
+    public List<MenteeStudyGroupDto> getAllGroups(Long studentNumber) {
+
+        User mentee = userRepository.findByStudentNumber(studentNumber)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+        List<GroupMember> groupMembers = groupMemberRepository.findByUserAndRoleWithStudyGroup(mentee, GroupMemberRole.MENTEE);
+
+        return groupMembers.stream()
+                .map(GroupMember::getStudyGroup)
+                .filter(Objects::nonNull) // null 체크
+                .map(studyGroup -> MenteeStudyGroupDto.builder()
+                        .studyGroupId(studyGroup.getStudyId())
+                        .name(studyGroup.getName())
+                        .category(studyGroup.getCategory())
+                        .studyImage(studyGroup.getStudyImage())
+                        .status(studyGroup.getStatus())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -82,7 +82,8 @@ public enum ResponseMessage {
     STUDY_MENTEE_GET_SUCCESS("스터디 멘티 멤버 반환 성공"),
     GET_ALL_GROUPS_SUCCESS("전체 스터디 그룹 정보 조회 성공"),
     GET_ALL_WARN_SUCCESS("스터디 멘티 멤버들 경고 조회 성공"),
-    UPDATE_GROUP_STATUS_SUCCESS("스터디 그룹 상태 변경 성공")
+    UPDATE_GROUP_STATUS_SUCCESS("스터디 그룹 상태 변경 성공"),
+    GET_ALL_MENTEE_GROUPS_SUCCESS("해당 멘티가 속한 모든 스터디 그룹 조회 성공")
     ;
     private final String message;
 }


### PR DESCRIPTION
## 변경사항
- 멘티가 수강한 / 수강중인 모든 스터디 그룹 정보를 반환하는 기능이 추가되었습니다.
<img width="708" height="371" alt="스크린샷 2025-09-17 오후 5 51 00" src="https://github.com/user-attachments/assets/3e869f02-bf35-4463-9772-193f5fe81d3d" />

GET 요청을 사용하며 필요한건 헤더에 들어가는 JWT 밖에 없습니다.

## 테스트
<img width="1260" height="946" alt="스크린샷 2025-09-17 오후 5 58 16" src="https://github.com/user-attachments/assets/43ae2004-5dfb-4e1c-ba5d-d9366d8c4dc0" />

참고 : status에 null이 들어가있는 스터디는 예전에 만들어진 것임으로 무시

--- 

<img width="203" height="191" alt="image" src="https://github.com/user-attachments/assets/cf6b5820-181f-419d-b15c-fb6160ac27e2" />
