### PR TITLE
fix(get-all-groups): removed filtering by GroupMemberRole

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/StudyGroupController.java
+++ b/src/main/java/com/mjsec/lms/controller/StudyGroupController.java
@@ -212,14 +212,14 @@ public class StudyGroupController {
     }
 
     @GetMapping("/all")
-    public ResponseEntity<SuccessResponse<List<MenteeStudyGroupDto>>> getAllGroups(Authentication authentication) {
+    public ResponseEntity<SuccessResponse<List<AllStudyGroupDto>>> getAllGroups(Authentication authentication) {
 
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();
-        List<MenteeStudyGroupDto> groups = studyGroupService.getAllGroups(currentUserStudentNumber);
+        List<AllStudyGroupDto> groups = studyGroupService.getAllGroups(currentUserStudentNumber);
 
         return ResponseEntity.ok(
                 SuccessResponse.of(
-                        ResponseMessage.GET_ALL_MENTEE_GROUPS_SUCCESS,
+                        ResponseMessage.GET_ALL_GROUPS_SUCCESS,
                         groups
                 )
         );

--- a/src/main/java/com/mjsec/lms/dto/AllStudyGroupDto.java
+++ b/src/main/java/com/mjsec/lms/dto/AllStudyGroupDto.java
@@ -6,7 +6,7 @@ import lombok.Data;
 
 @Data
 @Builder
-public class MenteeStudyGroupDto {
+public class AllStudyGroupDto {
 
     private Long studyGroupId;
 

--- a/src/main/java/com/mjsec/lms/repository/GroupMemberRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/GroupMemberRepository.java
@@ -40,6 +40,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     @Query("DELETE FROM GroupMember g WHERE g.studyGroup.creator = :user")
     void deleteByStudyGroupCreator(@Param("user") User user);
 
-    @Query("SELECT gm FROM GroupMember gm JOIN FETCH gm.studyGroup WHERE gm.user = :user AND gm.role = :role")
-    List<GroupMember> findByUserAndRoleWithStudyGroup(@Param("user") User user, @Param("role") GroupMemberRole role);
+    @Query("SELECT gm FROM GroupMember gm JOIN FETCH gm.studyGroup WHERE gm.user = :user")
+    List<GroupMember> findByUserWithStudyGroup(@Param("user") User user);
 }

--- a/src/main/java/com/mjsec/lms/repository/StudyGroupRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/StudyGroupRepository.java
@@ -2,6 +2,7 @@ package com.mjsec.lms.repository;
 
 import com.mjsec.lms.domain.StudyGroup;
 import com.mjsec.lms.domain.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;

--- a/src/main/java/com/mjsec/lms/service/StudyGroupService.java
+++ b/src/main/java/com/mjsec/lms/service/StudyGroupService.java
@@ -429,17 +429,17 @@ public class StudyGroupService {
                 .build();
     }
 
-    public List<MenteeStudyGroupDto> getAllGroups(Long studentNumber) {
+    public List<AllStudyGroupDto> getAllGroups(Long studentNumber) {
 
         User mentee = userRepository.findByStudentNumber(studentNumber)
                 .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
 
-        List<GroupMember> groupMembers = groupMemberRepository.findByUserAndRoleWithStudyGroup(mentee, GroupMemberRole.MENTEE);
+        List<GroupMember> groupMembers = groupMemberRepository.findByUserWithStudyGroup(mentee);
 
         return groupMembers.stream()
                 .map(GroupMember::getStudyGroup)
-                .filter(Objects::nonNull) // null 체크
-                .map(studyGroup -> MenteeStudyGroupDto.builder()
+                .filter(Objects::nonNull)
+                .map(studyGroup -> AllStudyGroupDto.builder()
                         .studyGroupId(studyGroup.getStudyId())
                         .name(studyGroup.getName())
                         .category(studyGroup.getCategory())

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -83,7 +83,6 @@ public enum ResponseMessage {
     GET_ALL_GROUPS_SUCCESS("전체 스터디 그룹 정보 조회 성공"),
     GET_ALL_WARN_SUCCESS("스터디 멘티 멤버들 경고 조회 성공"),
     UPDATE_GROUP_STATUS_SUCCESS("스터디 그룹 상태 변경 성공"),
-    GET_ALL_MENTEE_GROUPS_SUCCESS("해당 멘티가 속한 모든 스터디 그룹 조회 성공")
     ;
     private final String message;
 }


### PR DESCRIPTION
## 변경사항
- 기존에 본인이 속한 스터디그룹을 반환 받을 때 멘티인 그룹만을 반환했지만, 멘토 / 멘티 구분없이 소속된 모든 그룹 정보를 반환하도록 변경하였습니다.
<img width="735" height="58" alt="스크린샷 2025-09-17 오후 7 57 01" src="https://github.com/user-attachments/assets/297cc887-6300-4edd-8a1b-d3bdb2246558" />
