### PR TITLE
Feat: 스터디 그룹 수정 기능

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/MentorController.java
+++ b/src/main/java/com/mjsec/lms/controller/MentorController.java
@@ -1,19 +1,20 @@
 package com.mjsec.lms.controller;
 
 import com.mjsec.lms.domain.Plan;
-import com.mjsec.lms.dto.DetailPlanResponse;
-import com.mjsec.lms.dto.PlanDto;
-import com.mjsec.lms.dto.SuccessResponse;
+import com.mjsec.lms.dto.*;
 import com.mjsec.lms.service.MentorService;
 import com.mjsec.lms.service.PlanService;
+import com.mjsec.lms.service.StudyGroupService;
 import com.mjsec.lms.type.ResponseMessage;
 import com.mjsec.lms.util.ValidationUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 
@@ -25,6 +26,7 @@ public class MentorController {
     private final ValidationUtils validationUtils;
     private final MentorService mentorService;
     private final PlanService planService;
+    private final StudyGroupService studyGroupService;
 
     @PostMapping("/group/{groupId}/add-member/{studentNumber}")
     public ResponseEntity<SuccessResponse<Void>> addMember(
@@ -54,6 +56,28 @@ public class MentorController {
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessResponse.of(
                         ResponseMessage.DELETE_MEMBER_SUCCESS
+                )
+        );
+    }
+
+    //스터디 그룹 수정하기
+    @PutMapping("/group/{groupId}")
+    public ResponseEntity<SuccessResponse<StudyGroupPutResponse>> updateStudyGroup(
+            @PathVariable("groupId") Long groupId,
+            @Valid @RequestPart(value = "StudyGroupPutDto", required = false) StudyGroupPutDto dto,
+            @RequestPart(value = "image", required = false) MultipartFile image,
+            Authentication authentication){
+
+        validationUtils.validateStudyGroup(groupId);
+
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        StudyGroupPutResponse response = mentorService.updateStudyGroup(groupId,currentUserStudentNumber,image, dto);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.UPDATE_GROUP_SUCCESS,
+                        response
                 )
         );
     }
@@ -106,7 +130,7 @@ public class MentorController {
         );
     }
 
-    // 등록한 과제 삭제하기
+    // 등록한 계획 삭제하기
     @DeleteMapping("/group/{groupId}/plan/{planId}")
     public ResponseEntity<SuccessResponse<Void>> deletePlan(
             @PathVariable Long groupId,

--- a/src/main/java/com/mjsec/lms/dto/StudyGroupPutDto.java
+++ b/src/main/java/com/mjsec/lms/dto/StudyGroupPutDto.java
@@ -1,0 +1,17 @@
+package com.mjsec.lms.dto;
+
+import com.mjsec.lms.type.StudyStatus;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class StudyGroupPutDto {
+
+    private String name;
+
+    private String content;
+
+    private String studyImage;
+
+}

--- a/src/main/java/com/mjsec/lms/dto/StudyGroupPutResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/StudyGroupPutResponse.java
@@ -1,0 +1,18 @@
+package com.mjsec.lms.dto;
+
+import com.mjsec.lms.type.StudyStatus;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class StudyGroupPutResponse {
+
+    private Long studyId;
+
+    private String name;
+
+    private String content;
+
+    private String studyImage;
+}

--- a/src/main/java/com/mjsec/lms/service/MentorService.java
+++ b/src/main/java/com/mjsec/lms/service/MentorService.java
@@ -1,8 +1,12 @@
 package com.mjsec.lms.service;
 
 import com.mjsec.lms.domain.GroupMember;
+import com.mjsec.lms.domain.StudyActivity;
 import com.mjsec.lms.domain.StudyGroup;
 import com.mjsec.lms.domain.User;
+import com.mjsec.lms.dto.StudyActivityDto;
+import com.mjsec.lms.dto.StudyGroupPutDto;
+import com.mjsec.lms.dto.StudyGroupPutResponse;
 import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.repository.AttendanceRepository;
 import com.mjsec.lms.repository.GroupMemberRepository;
@@ -15,8 +19,11 @@ import com.mjsec.lms.repository.UserRepository;
 import com.mjsec.lms.type.ErrorCode;
 import java.util.List;
 import java.util.Objects;
+
+import com.mjsec.lms.util.ValidationUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Slf4j
@@ -29,12 +36,14 @@ public class MentorService {
     private final PlanCommentRepository planCommentRepository;
     private final AttendanceRepository attendanceRepository;
     private final StudyActivityRepository studyActivityRepository;
-    private final PlanRepository planRepository;
+    private final ValidationUtils validationUtils;
+    private final FileService fileService;
 
     public MentorService(UserRepository userRepository, StudyGroupRepository studyGroupRepository,
                          GroupMemberRepository groupMemberRepository, SubmissionRepository submissionRepository,
                          PlanCommentRepository planCommentRepository, AttendanceRepository attendanceRepository,
-                         StudyActivityRepository studyActivityRepository, PlanRepository planRepository) {
+                         StudyActivityRepository studyActivityRepository, ValidationUtils validationUtils,
+                         FileService fileService) {
 
         this.userRepository = userRepository;
         this.studyGroupRepository = studyGroupRepository;
@@ -43,7 +52,8 @@ public class MentorService {
         this.planCommentRepository = planCommentRepository;
         this.attendanceRepository = attendanceRepository;
         this.studyActivityRepository = studyActivityRepository;
-        this.planRepository = planRepository;
+        this.validationUtils = validationUtils;
+        this.fileService = fileService;
     }
 
     /**
@@ -155,6 +165,95 @@ public class MentorService {
 
         if(groupMember.getWarn() == 3) {
             groupMemberRepository.delete(groupMember);
+        }
+    }
+
+    /**
+     * 멘토가 스터디 그룹 수정하는 메소드
+     * @param currentStudentNumber 요청을 보낸 사용자의 학번
+     * @param groupId 스터디 그룹의 ID
+     */
+    public StudyGroupPutResponse updateStudyGroup(Long groupId, Long currentStudentNumber,MultipartFile image, StudyGroupPutDto dto) {
+
+        User user = validationUtils.validateUser(currentStudentNumber);
+        StudyGroup studyGroup = validationUtils.validateStudyGroup(groupId);
+        validationUtils.validateMentorRole(user.getUserId(), groupId);
+
+        updateStudyGroupData(studyGroup, dto);
+
+        handleImageUpdate(studyGroup,image,dto);
+
+        return StudyGroupPutResponse.builder()
+                .studyId(studyGroup.getStudyId())
+                .name(studyGroup.getName())
+                .content(studyGroup.getContent())
+                .studyImage(studyGroup.getStudyImage())
+                .build();
+    }
+    
+    /**
+    * PRiVATE 메서드들
+     */
+
+    private void updateStudyGroupData(StudyGroup studyGroup, StudyGroupPutDto dto) {
+
+        if(dto == null){
+            return;
+        }
+
+        boolean isUpdated = false;
+
+        if(dto.getName() != null && !dto.getName().trim().isEmpty()) {
+            studyGroup.setName(dto.getName());
+            isUpdated = true;
+        }
+
+        if(dto.getContent() != null && !dto.getContent().trim().isEmpty()){
+            studyGroup.setContent(dto.getContent());
+            isUpdated = true;
+        }
+
+        if(isUpdated) {
+            studyGroupRepository.save(studyGroup);
+        }
+    }
+
+    // 이미지 업데이트 처리를 위한 별도 메서드
+    private void handleImageUpdate(StudyGroup studyGroup, MultipartFile newImage, StudyGroupPutDto dto) {
+
+        String currentImageUrl = studyGroup.getStudyImage();
+
+        // 새 이미지가 업로드된 경우
+        if (newImage != null && !newImage.isEmpty()) {
+            log.info("New image uploaded, processing image replacement for StudyGroup: {}", studyGroup.getStudyId());
+
+            // 기존 이미지가 있다면 삭제
+            if (currentImageUrl != null && !currentImageUrl.trim().isEmpty()) {
+                try {
+                    fileService.deleteImage(currentImageUrl);
+                    log.info("Previous image deleted successfully: {}", currentImageUrl);
+                } catch (Exception e) {
+                    log.warn("Failed to delete previous image: {}, but continuing with new image upload",
+                            currentImageUrl, e);
+                }
+            }
+
+            // 새 이미지 업로드
+            try {
+                String newImageUrl = fileService.uploadImage(newImage);
+                studyGroup.setStudyImage(newImageUrl);
+                studyGroupRepository.save(studyGroup);
+                log.info("New image uploaded successfully: {}", newImageUrl);
+            } catch (Exception e) {
+                log.error("Failed to upload new image for StudyGroup: {}", studyGroup.getStudyId(), e);
+                // 새 이미지 업로드 실패시, 기존 이미지 URL 유지 (null로 설정하지 않음)
+                throw e; // 예외를 다시 던져서 트랜잭션 롤백 유도
+            }
+        }
+        // 새 이미지가 없는 경우: 기존 이미지 URL 유지 (수정하지 않음)
+        else {
+            log.info("No new image provided, keeping existing image: {}", currentImageUrl);
+            // 기존 imageUrl을 그대로 유지 - 별도 처리 불필요
         }
     }
 }

--- a/src/main/java/com/mjsec/lms/service/StudyGroupService.java
+++ b/src/main/java/com/mjsec/lms/service/StudyGroupService.java
@@ -254,6 +254,7 @@ public class StudyGroupService {
             try {
                 String newImageUrl = fileService.uploadImage(newImage);
                 studyActivity.setImageUrl(newImageUrl);
+                studyActivityRepository.save(studyActivity);
                 log.info("New image uploaded successfully: {}", newImageUrl);
             } catch (Exception e) {
                 log.error("Failed to upload new image for activity: {}", studyActivity.getActivityId(), e);

--- a/src/main/java/com/mjsec/lms/util/ValidationUtils.java
+++ b/src/main/java/com/mjsec/lms/util/ValidationUtils.java
@@ -104,6 +104,8 @@ public class ValidationUtils {
                 .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_ACTIVITY_NOT_FOUND));
     }
 
+
+
     // ========== 멤버십 및 역할 검증 ==========
 
     // 사용자가 해당 스터디 그룹의 멤버인지 확인


### PR DESCRIPTION
### 스터디 그룹 수정 (멘토)

**데이터**
```java
{
    "name":"웹해킹 변경!",
    "content":"변경된 내용"
}
``` 
그리고 이미지


테스트
<img width="636" height="502" alt="image" src="https://github.com/user-attachments/assets/f7dc7ed2-1982-4aa2-b0e5-a7e8fe73cf47" />

<img width="666" height="611" alt="image" src="https://github.com/user-attachments/assets/12184aa7-e4d6-47ab-bcb9-e0817ae6d764" />

이미지랑 Dto 다 빼고 해도 유지되도록 만듬

그 외 권한 관련해서는 너무 많은 테스트를 거쳤으므로 패스