### PR TITLE
Fix: 유저 삭제시 이미지 함께 삭제

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/UserController.java
+++ b/src/main/java/com/mjsec/lms/controller/UserController.java
@@ -57,6 +57,7 @@ public class UserController {
     ) {
 
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
         userService.updateUser(currentUserStudentNumber, profileImage, userUpdateDto);
 
         return ResponseEntity.ok(

--- a/src/main/java/com/mjsec/lms/repository/StudyGroupRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/StudyGroupRepository.java
@@ -23,4 +23,7 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
     @Modifying
     @Query("DELETE FROM StudyGroup s WHERE s.creator = :user")
     void deleteByCreator(@Param("user") User user);
+
+    @Query("SELECT s FROM StudyGroup s WHERE s.creator.userId = :userId")
+    List<StudyGroup> findByCreatorUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/mjsec/lms/service/AdminService.java
+++ b/src/main/java/com/mjsec/lms/service/AdminService.java
@@ -26,6 +26,8 @@ import com.mjsec.lms.type.UserRole;
 import com.mjsec.lms.type.StudyStatus;
 import jakarta.transaction.Transactional;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -295,6 +297,33 @@ public class AdminService {
         try {
             log.debug("1. 사용자 직접 관련 데이터 삭제 시작");
 
+            // 사용자 프로필 이미지 삭제
+            if (user.getProfileImage() != null && !user.getProfileImage().trim().isEmpty()) {
+                try {
+                    fileService.deleteImage(user.getProfileImage());
+                    log.info("User profile image deleted successfully: {}", user.getProfileImage());
+                } catch (Exception e) {
+                    log.warn("Failed to delete user profile image: {}, but continuing with user deletion",
+                            user.getProfileImage(), e);
+                }
+            }
+
+            //해당 사용자가 생성한 스터디 그룹들의 이미지 삭제
+            List<StudyGroup> userCreatedGroups = studyGroupRepository.findByCreatorUserId(userId);
+
+            for (StudyGroup studyGroup : userCreatedGroups) {
+                if (studyGroup.getStudyImage() != null && !studyGroup.getStudyImage().trim().isEmpty()) {
+                    try {
+                        fileService.deleteImage(studyGroup.getStudyImage());
+                        log.info("Study group image deleted successfully for group {}: {}",
+                                studyGroup.getStudyId(), studyGroup.getStudyImage());
+                    } catch (Exception e) {
+                        log.warn("Failed to delete study group image for group {}: {}, but continuing with deletion",
+                                studyGroup.getStudyId(), studyGroup.getStudyImage(), e);
+                    }
+                }
+            }
+
             submissionRepository.deleteBySubmitter(user);
             log.debug("- 과제 제출물 삭제 완료");
 
@@ -351,7 +380,7 @@ public class AdminService {
 
             studyGroupRepository.deleteByCreator(user);
             log.debug("- 스터디 그룹 삭제 완료");
-
+            
             log.debug("5. 사용자 엔티티 삭제");
             userRepository.delete(user);
 

--- a/src/main/java/com/mjsec/lms/service/FileService.java
+++ b/src/main/java/com/mjsec/lms/service/FileService.java
@@ -69,6 +69,41 @@ public class FileService {
         }
     }
 
+    // 이미지를 업데이트하는 통합 메서드
+    public String updateImage(String currentImageUrl, MultipartFile newImage, String entityName, Long entityId) {
+
+        // 새 이미지가 업로드된 경우
+        if (newImage != null && !newImage.isEmpty()) {
+            log.info("New image uploaded, processing image replacement for {}: {}", entityName, entityId);
+
+            // 기존 이미지가 있다면 삭제
+            if (currentImageUrl != null && !currentImageUrl.trim().isEmpty()) {
+                try {
+                    deleteImage(currentImageUrl);
+                    log.info("Previous image deleted successfully for {}: {}", entityName, currentImageUrl);
+                } catch (Exception e) {
+                    log.warn("Failed to delete previous image: {}, but continuing with new image upload for {}: {}",
+                            currentImageUrl, entityName, entityId, e);
+                }
+            }
+
+            // 새 이미지 업로드
+            try {
+                String newImageUrl = uploadImage(newImage);
+                log.info("New image uploaded successfully for {}: {}", entityName, newImageUrl);
+                return newImageUrl;
+            } catch (Exception e) {
+                log.error("Failed to upload new image for {}: {}", entityName, entityId, e);
+                // 새 이미지 업로드 실패시 예외를 다시 던져서 트랜잭션 롤백 유도
+                throw e;
+            }
+        }
+
+        // 새 이미지가 없는 경우: 기존 이미지 URL 유지
+        log.info("No new image provided for {}: {}, keeping existing image: {}", entityName, entityId, currentImageUrl);
+        return currentImageUrl;
+    }
+
     // 업로드할 이미지 파일의 유효성을 검사하는 메서드
     private void validateImageFile(MultipartFile file) {
         // 빈 파일인지 확인

--- a/src/main/java/com/mjsec/lms/service/MentorService.java
+++ b/src/main/java/com/mjsec/lms/service/MentorService.java
@@ -218,42 +218,19 @@ public class MentorService {
         }
     }
 
-    // 이미지 업데이트 처리를 위한 별도 메서드
+    //이미지 업데이트
     private void handleImageUpdate(StudyGroup studyGroup, MultipartFile newImage, StudyGroupPutDto dto) {
+        String newImageUrl = fileService.updateImage(
+                studyGroup.getStudyImage(),
+                newImage,
+                "StudyGroup",
+                studyGroup.getStudyId()
+        );
 
-        String currentImageUrl = studyGroup.getStudyImage();
-
-        // 새 이미지가 업로드된 경우
-        if (newImage != null && !newImage.isEmpty()) {
-            log.info("New image uploaded, processing image replacement for StudyGroup: {}", studyGroup.getStudyId());
-
-            // 기존 이미지가 있다면 삭제
-            if (currentImageUrl != null && !currentImageUrl.trim().isEmpty()) {
-                try {
-                    fileService.deleteImage(currentImageUrl);
-                    log.info("Previous image deleted successfully: {}", currentImageUrl);
-                } catch (Exception e) {
-                    log.warn("Failed to delete previous image: {}, but continuing with new image upload",
-                            currentImageUrl, e);
-                }
-            }
-
-            // 새 이미지 업로드
-            try {
-                String newImageUrl = fileService.uploadImage(newImage);
-                studyGroup.setStudyImage(newImageUrl);
-                studyGroupRepository.save(studyGroup);
-                log.info("New image uploaded successfully: {}", newImageUrl);
-            } catch (Exception e) {
-                log.error("Failed to upload new image for StudyGroup: {}", studyGroup.getStudyId(), e);
-                // 새 이미지 업로드 실패시, 기존 이미지 URL 유지 (null로 설정하지 않음)
-                throw e; // 예외를 다시 던져서 트랜잭션 롤백 유도
-            }
-        }
-        // 새 이미지가 없는 경우: 기존 이미지 URL 유지 (수정하지 않음)
-        else {
-            log.info("No new image provided, keeping existing image: {}", currentImageUrl);
-            // 기존 imageUrl을 그대로 유지 - 별도 처리 불필요
+        // 이미지 URL이 변경된 경우에만 저장
+        if (!Objects.equals(studyGroup.getStudyImage(), newImageUrl)) {
+            studyGroup.setStudyImage(newImageUrl);
+            studyGroupRepository.save(studyGroup);
         }
     }
 }

--- a/src/main/java/com/mjsec/lms/service/StudyGroupService.java
+++ b/src/main/java/com/mjsec/lms/service/StudyGroupService.java
@@ -230,42 +230,19 @@ public class StudyGroupService {
     그 외 Private 메서드
      */
 
-    // 이미지 업데이트 처리를 위한 별도 메서드
+    //이미지 처리를 위한 별도 메서드
     private void handleImageUpdate(StudyActivity studyActivity, MultipartFile newImage, StudyActivityDto dto) {
+        String newImageUrl = fileService.updateImage(
+                studyActivity.getImageUrl(),
+                newImage,
+                "StudyActivity",
+                studyActivity.getActivityId()
+        );
 
-        String currentImageUrl = studyActivity.getImageUrl();
-
-        // 새 이미지가 업로드된 경우
-        if (newImage != null && !newImage.isEmpty()) {
-            log.info("New image uploaded, processing image replacement for activity: {}", studyActivity.getActivityId());
-
-            // 기존 이미지가 있다면 삭제
-            if (currentImageUrl != null && !currentImageUrl.trim().isEmpty()) {
-                try {
-                    fileService.deleteImage(currentImageUrl);
-                    log.info("Previous image deleted successfully: {}", currentImageUrl);
-                } catch (Exception e) {
-                    log.warn("Failed to delete previous image: {}, but continuing with new image upload",
-                            currentImageUrl, e);
-                }
-            }
-
-            // 새 이미지 업로드
-            try {
-                String newImageUrl = fileService.uploadImage(newImage);
-                studyActivity.setImageUrl(newImageUrl);
-                studyActivityRepository.save(studyActivity);
-                log.info("New image uploaded successfully: {}", newImageUrl);
-            } catch (Exception e) {
-                log.error("Failed to upload new image for activity: {}", studyActivity.getActivityId(), e);
-                // 새 이미지 업로드 실패시, 기존 이미지 URL 유지 (null로 설정하지 않음)
-                throw e; // 예외를 다시 던져서 트랜잭션 롤백 유도
-            }
-        }
-        // 새 이미지가 없는 경우: 기존 이미지 URL 유지 (수정하지 않음)
-        else {
-            log.info("No new image provided, keeping existing image: {}", currentImageUrl);
-            // 기존 imageUrl을 그대로 유지 - 별도 처리 불필요
+        // 이미지 URL이 변경된 경우에만 저장
+        if (!Objects.equals(studyActivity.getImageUrl(), newImageUrl)) {
+            studyActivity.setImageUrl(newImageUrl);
+            studyActivityRepository.save(studyActivity);
         }
     }
 

--- a/src/main/java/com/mjsec/lms/service/UserService.java
+++ b/src/main/java/com/mjsec/lms/service/UserService.java
@@ -1,7 +1,9 @@
 package com.mjsec.lms.service;
 
 import com.mjsec.lms.domain.GroupMember;
+import com.mjsec.lms.domain.StudyActivity;
 import com.mjsec.lms.domain.User;
+import com.mjsec.lms.dto.StudyActivityDto;
 import com.mjsec.lms.dto.StudyGroupSummaryDto;
 import com.mjsec.lms.dto.UserResponse;
 import com.mjsec.lms.dto.UserUpdateDto;
@@ -15,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -129,10 +132,7 @@ public class UserService {
         User user = userRepository.findByStudentNumber(currentStudentNumber)
                 .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
 
-        if(profileImage != null && !profileImage.isEmpty()) {
-            String imgUrl = fileService.uploadImage(profileImage);
-            user.setProfileImage(imgUrl);
-        }
+        handleImageUpdate(user, profileImage);
 
         if(userUpdateDto != null) {
             if(userUpdateDto.getName() != null && !userUpdateDto.getName().trim().isEmpty()) {
@@ -149,5 +149,21 @@ public class UserService {
         }
 
         userRepository.save(user);
+    }
+
+    //이미지 처리를 위한 별도 메서드
+    private void handleImageUpdate(User user, MultipartFile newImage) {
+        String newImageUrl = fileService.updateImage(
+                user.getProfileImage(),
+                newImage,
+                "User",
+                user.getUserId()
+        );
+
+        // 이미지 URL이 변경된 경우에만 저장
+        if (!Objects.equals(user.getProfileImage(), newImageUrl)) {
+            user.setProfileImage(newImageUrl);
+            userRepository.save(user);
+        }
     }
 }


### PR DESCRIPTION
### 유저 삭제시 이미지 함께 삭제

유저 삭제시
* 유저 프로필 이미지 삭제
* 유저가 멘토인 스터디 그룹의 이미지 삭제 (스터디 그룹도 함께 삭제되는 구조)

**테스트**

지워질 유저를 하나 만듬. (스터디 멘토로도 함께 설정 + 이미지 모두 추가)
<img width="696" height="670" alt="image" src="https://github.com/user-attachments/assets/4d074ed8-b3de-4c19-9c47-e53911498b72" />

유저 삭제
<img width="383" height="437" alt="image" src="https://github.com/user-attachments/assets/760ba4e9-2e8a-4bdc-ab56-aaac9d8d3040" />

이미지 삭제됨을 확인함과 동시에 로그
<img width="828" height="135" alt="image" src="https://github.com/user-attachments/assets/e2f7a8ca-108c-4e83-ac3f-afbb0cd3a9b4" />

---

진짜 겁나 피곤한 날이다 그죠
