### PR TITLE
feat(check-group-name): add check-group-name feature for group update

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/AdminController.java
+++ b/src/main/java/com/mjsec/lms/controller/AdminController.java
@@ -81,6 +81,27 @@ public class AdminController {
         );
     }
 
+    @GetMapping("/group/name-check/{name}")
+    public ResponseEntity<SuccessResponse<Boolean>> checkGroupName(@PathVariable("name") String name) {
+
+        if(adminService.checkGroupName(name)) {
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    SuccessResponse.of(
+                            ResponseMessage.GROUP_NAME_CHECK_SUCCESS,
+                            true
+                    )
+            );
+        }
+        else {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                    SuccessResponse.of(
+                            ResponseMessage.DUPLICATE_GROUP_NAME,
+                            false
+                    )
+            );
+        }
+    }
+
     @PostMapping("/group")
     public ResponseEntity<SuccessResponse<Void>> createGroup(@Valid @RequestBody StudyGroupRequestDto studyGroupDto){
 

--- a/src/main/java/com/mjsec/lms/service/AdminService.java
+++ b/src/main/java/com/mjsec/lms/service/AdminService.java
@@ -185,6 +185,21 @@ public class AdminService {
     }
 
     /**
+     * 사용 중인 스터디 이름인지 체크하는 메소드
+     * @param name 새로운 스터디 이름
+     * @return true / false
+     */
+    public boolean checkGroupName(String name) {
+
+        if(studyGroupRepository.existsByName(name)){
+            return false;
+        }
+        else {
+            return true;
+        }
+    }
+
+    /**
      * 스터디 그룹을 생성하는 메소드
      * @param requestDto 스터디 그룹명, 스터디 소개, 스터디 타입, 멘토 학번
      */

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -83,6 +83,8 @@ public enum ResponseMessage {
     GET_ALL_GROUPS_SUCCESS("전체 스터디 그룹 정보 조회 성공"),
     GET_ALL_WARN_SUCCESS("스터디 멘티 멤버들 경고 조회 성공"),
     UPDATE_GROUP_STATUS_SUCCESS("스터디 그룹 상태 변경 성공"),
+    GROUP_NAME_CHECK_SUCCESS("사용 가능한 스터디 이름"),
+    DUPLICATE_GROUP_NAME("사용 중인 스터디 이름")
     ;
     private final String message;
 }


### PR DESCRIPTION
## 변경사항
- (스터디 그룹 수정 시) 기존에 있는 스터디 이름인지 확인하는 API가 추가되었습니다.
<img width="601" height="96" alt="스크린샷 2025-09-19 오전 12 36 49" src="https://github.com/user-attachments/assets/5c660e58-5e5b-4aef-8c67-33ba0d9673b5" />

true / false 값을 리턴합니다. 

주의 (매우 중요) : PathVariable에 스터디 이름이 들어가는데 한글일 수도 있으므로 프론트 측에서는 encodeURIComponent() 사용해야 함

## 테스트
<img width="1470" height="920" alt="스크린샷 2025-09-19 오전 12 25 15" src="https://github.com/user-attachments/assets/9efd60e1-4488-431b-9cca-b991b8467eab" />

테스트하고자 하는 스터디 이름 : 백투백
<img width="1260" height="946" alt="스크린샷 2025-09-19 오전 12 35 27" src="https://github.com/user-attachments/assets/c30dea4f-bb3e-4c9e-9513-4fc83bc6da88" />

만약 DB에 없는 스터디 이름이라면 true 반환 (참고 : PathVariable에 한글이 들어가지 않을 경우 인코딩은 불필요)
<img width="1260" height="946" alt="스크린샷 2025-09-19 오전 12 39 37" src="https://github.com/user-attachments/assets/5ac41782-babb-4036-95fb-5b39e83d642a" />
