### PR TITLE
fix(server-time): fixed yml file for sync time zone

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
     secret: ${JWT_SECRET}
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=UTC&CharacterEncoding=UTF-8
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&CharacterEncoding=UTF-8
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
   jpa:


### PR DESCRIPTION
## 변경사항

- 문제점 : 잘못된 날짜가 저장되는 문제
<img width="582" height="332" alt="스크린샷 2025-09-19 오후 4 45 37" src="https://github.com/user-attachments/assets/52afcff7-6e5f-408a-8bd9-edbee18b690a" />

- yml 파일을 보니 time zone이 충돌나는 것 같아 jdbc 설정에서 UTC를 Asia/Seoul로 변경하였습니다.
<img width="882" height="409" alt="스크린샷 2025-09-19 오후 4 46 12" src="https://github.com/user-attachments/assets/b4c182b0-afdb-4e8e-9fa4-03971b04ce48" />
