### PR TITLE
fix(login-studen-number): fixed error code message

### DIFF
--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
 
     // 학번 관련 에러
     DUPLICATE_STUDENT_NUMBER(HttpStatus.CONFLICT, "사용할 수 없는 학번 입니다."),
-    INVALID_STUDENT_NUMBER(HttpStatus.BAD_REQUEST, "학번은 8자리 숫자 입니다."),
+    INVALID_STUDENT_NUMBER(HttpStatus.BAD_REQUEST, "등록되지 않았거나 유효하지 않은 학번 입니다."),
 
     // 이메일 관련 에러
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다."),


### PR DESCRIPTION
## 변경사항

- 문제점 : 계정이 없는데 8자리 학번을 입력하는 경우 "등록되지 않은 학번 입니다"와 같은 메시지가 아닌 "학번은 8자리 숫자 입니다."라는 맥락에 맞지 않는 메시지 반환
<img width="583" height="489" alt="스크린샷 2025-09-19 오후 4 54 19" src="https://github.com/user-attachments/assets/82f8e070-987c-41e0-be2d-8b564f4527e2" />

- 해결책 : ErrorCode 파일 수정
<img width="802" height="79" alt="스크린샷 2025-09-19 오후 4 54 50" src="https://github.com/user-attachments/assets/4fbd1275-b5b9-4345-bfde-9f1e4990f9a2" />
