### PR TITLE
fix(pending user): add createdAt in PendingUser, AuthService.register and AdminService.getAllPendingUser for missing return value

### DIFF
--- a/src/main/java/com/mjsec/lms/domain/PendingUser.java
+++ b/src/main/java/com/mjsec/lms/domain/PendingUser.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,4 +38,7 @@ public class PendingUser{
 
     @Column(nullable = false)
     private String phoneNumber;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/mjsec/lms/service/AdminService.java
+++ b/src/main/java/com/mjsec/lms/service/AdminService.java
@@ -86,6 +86,7 @@ public class AdminService {
                         .name(user.getName())
                         .email(user.getEmail())
                         .phoneNumber(user.getPhoneNumber())
+                        .createdAt(user.getCreatedAt())
                         .build())
                 .toList();
     }

--- a/src/main/java/com/mjsec/lms/service/AuthService.java
+++ b/src/main/java/com/mjsec/lms/service/AuthService.java
@@ -7,6 +7,7 @@ import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.repository.PendingUserRepository;
 import com.mjsec.lms.repository.UserRepository;
 import com.mjsec.lms.type.ErrorCode;
+import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -121,6 +122,7 @@ public class AuthService {
                 .name(userDto.getName())
                 .email(userDto.getEmail())
                 .phoneNumber(userDto.getPhoneNumber())
+                .createdAt(LocalDateTime.now())
                 .build();
 
         pendingUserRepository.save(pendingUser);


### PR DESCRIPTION
## 변경사항

- 문제점 : 회원가입 승인 요청 대기자 목록 반환시 createdAt이 null 로 뜨는 문제
<img width="585" height="177" alt="스크린샷 2025-09-19 오후 5 29 42" src="https://github.com/user-attachments/assets/56488659-1a45-4eac-847f-6043fff196b0" />

- 원인1 : PendingUserDto에는 createdAt이 있지만, PendingUser 엔티티에는 없음
<img width="1470" height="920" alt="스크린샷 2025-09-19 오후 5 18 53" src="https://github.com/user-attachments/assets/8fee5a9a-4c33-442c-b95f-57703b95a528" />

- 원인2 : AdminService에서 PendingUserDto 리스트 반환을 위해 엔티티와 Dto간 매핑 시 createdAt을 넣어주지 않음

- 원인3 : AuthService에서 회원가입 승인 요청 시 cratedAt을 넣어주지 않음

- 해결과정
1. PendingUser 엔티티에 createdAt 컬럼 추가
<img width="475" height="586" alt="스크린샷 2025-09-19 오후 5 33 31" src="https://github.com/user-attachments/assets/5ed1e19a-7fbc-457e-9276-4dbee3401cfd" />

2. AdminService에서 PendingUserDto 리스트 반환을 위해 엔티티와 Dto간 매핑 시 createdAt 할당
<img width="621" height="396" alt="스크린샷 2025-09-19 오후 5 34 09" src="https://github.com/user-attachments/assets/325388b3-9c4f-489b-accd-ebc0e4eedd1d" />

3. AuthService에서 회원가입 승인 요청 시 cratedAt 할당
<img width="616" height="268" alt="스크린샷 2025-09-19 오후 5 34 56" src="https://github.com/user-attachments/assets/14e0f451-125e-471c-b466-c28f560e2071" />

---

## 테스트

1. 회원가입 승인 요청 API 호출
<img width="1260" height="946" alt="스크린샷 2025-09-19 오후 5 20 01" src="https://github.com/user-attachments/assets/c97337c8-e820-40b6-95a8-b98371031b7f" />

2. 관리자로 로그인 후, 회원가입 승인 대기 목록 조회
<img width="1260" height="946" alt="스크린샷 2025-09-19 오후 5 21 30" src="https://github.com/user-attachments/assets/e346912c-0ccd-40c3-9512-5285ccbb325a" />

---

더 이상 에러는 없겠지...
<img width="1440" height="906" alt="image" src="https://github.com/user-attachments/assets/1f22698f-41ae-4d34-b2fe-5da94ff10587" />







