### PR TITLE
Fix:스터디그룹 기수 추가

### DIFF
--- a/src/main/java/com/mjsec/lms/domain/StudyGroup.java
+++ b/src/main/java/com/mjsec/lms/domain/StudyGroup.java
@@ -38,6 +38,9 @@ public class StudyGroup extends BaseEntity {
     @Column(name = "study_image", columnDefinition = "TEXT")
     private String studyImage;
 
+    @Column(name = "generation", nullable = false, length = 10)
+    private String generation;
+
     @Enumerated(EnumType.ORDINAL)
     @Column(name = "status", nullable = false)
     private StudyStatus status;

--- a/src/main/java/com/mjsec/lms/dto/AllStudyGroupDto.java
+++ b/src/main/java/com/mjsec/lms/dto/AllStudyGroupDto.java
@@ -16,5 +16,7 @@ public class AllStudyGroupDto {
 
     private String studyImage;
 
+    private String generation;
+
     private StudyStatus status;
 }

--- a/src/main/java/com/mjsec/lms/dto/StudyGroupDto.java
+++ b/src/main/java/com/mjsec/lms/dto/StudyGroupDto.java
@@ -1,10 +1,7 @@
 package com.mjsec.lms.dto;
 
 import com.mjsec.lms.type.Category;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.Data;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,6 +30,10 @@ public class StudyGroupDto {
         @Min(value = 10000000, message = "멘토 학번은 8자리 숫자여야 합니다.")
         @Max(value = 99999999, message = "멘토 학번은 8자리 숫자여야 합니다.")
         private Long mentorStudentNumber;
+
+        @NotBlank(message = "기수 정보는 필수 입력값 입니다.")
+        @Pattern(regexp = "^[1-9]\\d*(\\.5)?기$", message = "기수는 '1기', '1.5기', '2기' 형식으로 입력해주세요.")
+        private String generation;
     }
 
     @Data
@@ -48,6 +49,8 @@ public class StudyGroupDto {
         private String description;
 
         private Category category;
+
+        private String generation;
 
         private String studyImage;
 
@@ -71,5 +74,8 @@ public class StudyGroupDto {
         @Min(value = 10000000, message = "멘토 학번은 8자리 숫자여야 합니다.")
         @Max(value = 99999999, message = "멘토 학번은 8자리 숫자여야 합니다.")
         private Long mentorStudentNumber;
+
+        @Pattern(regexp = "^[1-9]\\d*(\\.5)?기$", message = "기수는 '1기', '1.5기', '2기' 형식으로 입력해주세요.")
+        private String generation;
     }
 }

--- a/src/main/java/com/mjsec/lms/dto/StudyGroupPutResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/StudyGroupPutResponse.java
@@ -14,5 +14,7 @@ public class StudyGroupPutResponse {
 
     private String content;
 
+    private String generation;
+
     private String studyImage;
 }

--- a/src/main/java/com/mjsec/lms/dto/StudyGroupSummaryDto.java
+++ b/src/main/java/com/mjsec/lms/dto/StudyGroupSummaryDto.java
@@ -13,5 +13,7 @@ public class StudyGroupSummaryDto {
 
     private String category;
 
+    private String generation;
+
     private String studyImage;
 }

--- a/src/main/java/com/mjsec/lms/service/AdminService.java
+++ b/src/main/java/com/mjsec/lms/service/AdminService.java
@@ -175,6 +175,7 @@ public class AdminService {
                             .name(studyGroup.getName())
                             .category(studyGroup.getCategory())
                             .studyImage(studyGroup.getStudyImage())
+                            .generation(studyGroup.getGeneration())
                             .status(studyGroup.getStatus())
                             .build();
                 })
@@ -218,6 +219,7 @@ public class AdminService {
                 .name(requestDto.getName())
                 .category(requestDto.getCategory().name())
                 .content(requestDto.getContent())
+                .generation(requestDto.getGeneration())
                 .creator(mentor)
                 .status(StudyStatus.ACTIVE)
                 .build();
@@ -265,6 +267,10 @@ public class AdminService {
 
             if (studyGroupUpdateDto.getContent() != null && !studyGroupUpdateDto.getContent().trim().isEmpty()) {
                 studyGroup.setContent(studyGroupUpdateDto.getContent());
+            }
+
+            if (studyGroupUpdateDto.getGeneration() != null && !studyGroupUpdateDto.getGeneration().trim().isEmpty()) {
+                studyGroup.setGeneration(studyGroupUpdateDto.getGeneration());
             }
 
             if (studyGroupUpdateDto.getMentorStudentNumber() != null) {

--- a/src/main/java/com/mjsec/lms/service/StudyGroupService.java
+++ b/src/main/java/com/mjsec/lms/service/StudyGroupService.java
@@ -422,6 +422,7 @@ public class StudyGroupService {
                         .name(studyGroup.getName())
                         .category(studyGroup.getCategory())
                         .studyImage(studyGroup.getStudyImage())
+                        .generation(studyGroup.getGeneration())
                         .status(studyGroup.getStatus())
                         .build())
                 .collect(Collectors.toList());

--- a/src/main/java/com/mjsec/lms/service/UserService.java
+++ b/src/main/java/com/mjsec/lms/service/UserService.java
@@ -82,6 +82,7 @@ public class UserService {
                 .studyGroupId(groupMember.getStudyGroup().getStudyId())
                 .name(groupMember.getStudyGroup().getName())
                 .category(groupMember.getStudyGroup().getCategory())
+                .generation(groupMember.getStudyGroup().getGeneration())
                 .studyImage(groupMember.getStudyGroup().getStudyImage())
                 .build();
     }


### PR DESCRIPTION
어드민 기준
* 스터디 그룹 생성
* 스터디 그룹 수정
* 전체 스터디 그룹 조회
각 기능에서 generation (기수) 변수를 추가했습니다

**테스트**

스터디그룹 생성

<img width="541" height="504" alt="image" src="https://github.com/user-attachments/assets/8df7f1e8-9f41-42ca-a6db-bbc8e5570cc9" />

수정 + 전체 조회
여기서 첫번째 generation 이 "1" 로 표기되는 건 mysql 상에서 오류가 안 나오도록 모든 스터디그룹에 generation을 1로 추가해뒀기 때문입니다.
실제 로직상엔 문제 없어요

<img width="587" height="636" alt="image" src="https://github.com/user-attachments/assets/16a287d2-3a68-4fcf-bbdb-9dce683897bf" />
