### PR TITLE
Feat:특정 스터디그룹 정보 조회

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/StudyGroupController.java
+++ b/src/main/java/com/mjsec/lms/controller/StudyGroupController.java
@@ -21,7 +21,8 @@ public class StudyGroupController {
     private final StudyGroupService studyGroupService;
     private final ValidationUtils validationUtils;
 
-    StudyGroupController(StudyGroupService studyGroupService, ValidationUtils validationUtils){
+    StudyGroupController(StudyGroupService studyGroupService, ValidationUtils validationUtils) {
+
         this.studyGroupService = studyGroupService;
         this.validationUtils = validationUtils;
     }
@@ -46,6 +47,7 @@ public class StudyGroupController {
                 )
         );
     }
+
 
     //스터디 멘티 멤버만 반환
     @GetMapping("/{groupId}/mentee")
@@ -221,6 +223,25 @@ public class StudyGroupController {
                 SuccessResponse.of(
                         ResponseMessage.GET_ALL_GROUPS_SUCCESS,
                         groups
+                )
+        );
+    }
+
+    // 특정 그룹 상세 정보 조회
+    @GetMapping("/{groupId}/info")
+    public ResponseEntity<SuccessResponse<StudyGroupDetailDto>> getStudyGroupDetail(
+            @PathVariable Long groupId,
+            Authentication authentication) {
+
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        StudyGroupDetailDto studyGroupDetail = studyGroupService.getStudyGroupDetail(groupId, currentUserStudentNumber);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.STUDY_GROUP_DETAIL_GET_SUCCESS,
+                        studyGroupDetail
                 )
         );
     }

--- a/src/main/java/com/mjsec/lms/dto/StudyGroupDetailDto.java
+++ b/src/main/java/com/mjsec/lms/dto/StudyGroupDetailDto.java
@@ -1,0 +1,49 @@
+package com.mjsec.lms.dto;
+
+import com.mjsec.lms.type.StudyStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class StudyGroupDetailDto {
+
+    private Long studyId;
+
+    private String name;
+
+    private String content;
+
+    private String category;
+
+    private String generation;
+
+    private String studyImage;
+
+    private StudyStatus status;
+
+    // 멘토 정보
+    private String mentorName;
+
+    private Long mentorStudentNumber;
+
+    // 멘티 리스트
+    private List<MenteeInfo> menteeList;
+
+    private int menteeCount;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @Data
+    @Builder
+    public static class MenteeInfo {
+        private String name;
+        private Long studentNumber;
+        private String email;
+    }
+}

--- a/src/main/java/com/mjsec/lms/service/StudyGroupService.java
+++ b/src/main/java/com/mjsec/lms/service/StudyGroupService.java
@@ -125,6 +125,7 @@ public class StudyGroupService {
         return createStudyActivityResponse(savedStudyActivity, attendanceList);
     }
 
+    //스터디 활동 글 수정하기
     @Transactional
     public StudyActivityResponse updateStudyActivity(Long groupId, Long activityId,
                                                      Long currentUserStudentNumber, StudyActivityDto studyActivityDto, MultipartFile image) {
@@ -224,6 +225,40 @@ public class StudyGroupService {
         log.info("Found study activity: {} with title: {}", activityId, studyActivity.getTitle());
 
         return createStudyActivityResponse(studyActivity, studyActivity.getAttendances());
+    }
+
+    // 특정 그룹 상세 정보 조회
+    @Transactional(readOnly = true)
+    public StudyGroupDetailDto getStudyGroupDetail(Long groupId, Long currentUserStudentNumber) {
+
+        log.info("getStudyGroupDetail called for group: {} by user: {}", groupId, currentUserStudentNumber);
+
+        // 기본 접근 권한 검증 (해당 그룹의 멤버인지 확인)
+        validationUtils.validateBasicAccess(groupId, currentUserStudentNumber);
+        StudyGroup studyGroup = validationUtils.validateStudyGroup(groupId);
+
+        // 그룹의 모든 멤버 조회
+        List<GroupMember> allMembers = groupMemberRepository.findByStudyGroup_StudyId(groupId);
+
+        // 멘토와 멘티 분리
+        GroupMember mentor = allMembers.stream()
+                .filter(member -> member.getRole() == GroupMemberRole.MENTOR)
+                .findFirst()
+                .orElse(null);
+
+        List<GroupMember> mentees = allMembers.stream()
+                .filter(member -> member.getRole() == GroupMemberRole.MENTEE)
+                .toList();
+
+        // 멘티 정보 DTO 리스트 생성
+        List<StudyGroupDetailDto.MenteeInfo> menteeInfoList = mentees.stream()
+                .map(this::createMenteeInfo)
+                .collect(Collectors.toList());
+
+        log.info("Found {} total members in study group: {} (1 mentor, {} mentees)",
+                allMembers.size(), groupId, mentees.size());
+
+        return createStudyGroupDetailDto(studyGroup, mentor, menteeInfoList);
     }
 
     /*
@@ -426,5 +461,41 @@ public class StudyGroupService {
                         .status(studyGroup.getStatus())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    //그룹 상세 정보 DTO 생성
+    private StudyGroupDetailDto createStudyGroupDetailDto(StudyGroup studyGroup, GroupMember mentor,
+                                                          List<StudyGroupDetailDto.MenteeInfo> menteeList) {
+
+        StudyGroupDetailDto.StudyGroupDetailDtoBuilder builder = StudyGroupDetailDto.builder()
+                .studyId(studyGroup.getStudyId())
+                .name(studyGroup.getName())
+                .content(studyGroup.getContent())
+                .category(studyGroup.getCategory())
+                .generation(studyGroup.getGeneration())
+                .studyImage(studyGroup.getStudyImage())
+                .status(studyGroup.getStatus())
+                .menteeList(menteeList)
+                .menteeCount(menteeList.size())
+                .createdAt(studyGroup.getCreatedAt())
+                .updatedAt(studyGroup.getUpdatedAt());
+
+        // 멘토 정보 설정
+        if (mentor != null && mentor.getUser() != null) {
+            builder.mentorName(mentor.getUser().getName())
+                    .mentorStudentNumber(mentor.getUser().getStudentNumber());
+        }
+
+        return builder.build();
+    }
+
+    //멘티 정보 DTO 생성
+    private StudyGroupDetailDto.MenteeInfo createMenteeInfo(GroupMember mentee) {
+
+        return StudyGroupDetailDto.MenteeInfo.builder()
+                .name(mentee.getUser().getName())
+                .studentNumber(mentee.getUser().getStudentNumber())
+                .email(mentee.getUser().getEmail())
+                .build();
     }
 }

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -84,7 +84,8 @@ public enum ResponseMessage {
     GET_ALL_WARN_SUCCESS("스터디 멘티 멤버들 경고 조회 성공"),
     UPDATE_GROUP_STATUS_SUCCESS("스터디 그룹 상태 변경 성공"),
     GROUP_NAME_CHECK_SUCCESS("사용 가능한 스터디 이름"),
-    DUPLICATE_GROUP_NAME("사용 중인 스터디 이름")
+    DUPLICATE_GROUP_NAME("사용 중인 스터디 이름"),
+    STUDY_GROUP_DETAIL_GET_SUCCESS("스터디 그룹 상세 정보 조회 성공"),
     ;
     private final String message;
 }


### PR DESCRIPTION
### 특정 스터디그룹 정보 조회

멘토 멘티 권한을 가진 사람들이 조회할 수 있도록 만듬

<img width="625" height="558" alt="image" src="https://github.com/user-attachments/assets/bfe8f94e-380e-49c1-9fdb-c16f6a799333" />

여기 나와있는 generation은 무시하십쇼 원래는 1기 1.5기 이런 식으로 표기되는 게 맞음. 

멘토 멘티 둘 다 가능한거 확인함.