### PR TITLE
feat(delete group): add group deletion feature for admin

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/AdminController.java
+++ b/src/main/java/com/mjsec/lms/controller/AdminController.java
@@ -130,6 +130,18 @@ public class AdminController {
         );
     }
 
+    @DeleteMapping("/group/{name}")
+    public ResponseEntity<SuccessResponse<Void>> deleteGroup(@PathVariable String name) {
+
+        adminService.deleteGroup(name);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.DELETE_GROUP_SUCCESS
+                )
+        );
+    }
+
     @GetMapping("/users")
     public ResponseEntity<SuccessResponse<List<UserAdminResponseDto>>> getAllUsersForAdmin() {
 

--- a/src/main/java/com/mjsec/lms/repository/AttendanceRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/AttendanceRepository.java
@@ -63,4 +63,6 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
             "WHERE a.user.userId = :userId " +
             "AND a.studyGroup.studyId = :studyId")
     List<Long> findIdsByUserIdAndStudyGroupId(@Param("userId") Long userId, @Param("studyId") Long studyId);
+
+    List<Attendance> findByStudyActivityActivityId(Long activityId);
 }

--- a/src/main/java/com/mjsec/lms/repository/PlanCommentRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/PlanCommentRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 @Repository
 public interface PlanCommentRepository extends JpaRepository<PlanComment, Long> {
 
-    public List<PlanComment> findAllByPlanPlanId(Long planId);
+    List<PlanComment> findAllByPlanPlanId(Long planId);
 
     // 댓글 ID와 작성자 ID로 댓글 조회
     Optional<PlanComment> findByCommentIdAndAuthor_UserId(Long commentId, Long userId);

--- a/src/main/java/com/mjsec/lms/service/AdminService.java
+++ b/src/main/java/com/mjsec/lms/service/AdminService.java
@@ -1,7 +1,12 @@
 package com.mjsec.lms.service;
 
+import com.mjsec.lms.domain.AssignmentSubmission;
+import com.mjsec.lms.domain.Attendance;
 import com.mjsec.lms.domain.GroupMember;
 import com.mjsec.lms.domain.PendingUser;
+import com.mjsec.lms.domain.Plan;
+import com.mjsec.lms.domain.PlanComment;
+import com.mjsec.lms.domain.StudyActivity;
 import com.mjsec.lms.domain.StudyGroup;
 import com.mjsec.lms.domain.User;
 import com.mjsec.lms.dto.AllStudyGroupDto;
@@ -282,6 +287,53 @@ public class AdminService {
         }
 
         studyGroupRepository.save(studyGroup);
+    }
+
+    /**
+     * 스터디 그룹을 삭제시키는 메소드
+     * @param name 스터디 그룹 이름
+     */
+    public void deleteGroup(String name) {
+
+        log.info("Admin attempting to delete study group: {}", name);
+
+        StudyGroup studyGroup = studyGroupRepository.findByName(name)
+                .orElseThrow(() -> new RestApiException(ErrorCode.STUDY_NOT_FOUND));
+
+        Long studyId = studyGroup.getStudyId();
+        log.debug("Deleting related data for study group ID: {}", studyId);
+
+        List<Plan> plans = planRepository.findAllByStudyGroup_StudyId(studyId);
+        for (Plan plan : plans) {
+            Long planId = plan.getPlanId();
+
+            List<AssignmentSubmission> submissions = submissionRepository.findAssignmentSubmissionsByPlanPlanId(planId);
+            submissionRepository.deleteAll(submissions);
+
+            List<PlanComment> comments = planCommentRepository.findAllByPlanPlanId(planId);
+            planCommentRepository.deleteAll(comments);
+
+            planRepository.deleteById(planId);
+            log.debug("Deleted plan and related data for plan ID: {}", planId);
+        }
+
+        List<StudyActivity> activities = studyActivityRepository.findAllByStudyGroupId(studyId);
+        for (StudyActivity activity : activities) {
+            Long activityId = activity.getActivityId();
+
+            List<Attendance> attendances = attendanceRepository.findByStudyActivityActivityId(activityId);
+            attendanceRepository.deleteAll(attendances);
+
+            studyActivityRepository.deleteById(activityId);
+            log.debug("Deleted activity and related data for activity ID: {}", activityId);
+        }
+
+        List<GroupMember> members = groupMemberRepository.findByStudyGroup_StudyId(studyId);
+        groupMemberRepository.deleteAll(members);
+
+        studyGroupRepository.delete(studyGroup);
+
+        log.info("Successfully deleted study group: {}", name);
     }
 
     /**

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -86,6 +86,7 @@ public enum ResponseMessage {
     GROUP_NAME_CHECK_SUCCESS("사용 가능한 스터디 이름"),
     DUPLICATE_GROUP_NAME("사용 중인 스터디 이름"),
     STUDY_GROUP_DETAIL_GET_SUCCESS("스터디 그룹 상세 정보 조회 성공"),
+    DELETE_GROUP_SUCCESS("스터디 그룹 삭제 성공"),
     ;
     private final String message;
 }


### PR DESCRIPTION
## 변경사항

- ADMIN 권한으로 그룹을 삭제시키는 API가 추가되었습니다.
<img width="595" height="59" alt="스크린샷 2025-09-22 오후 6 51 58" src="https://github.com/user-attachments/assets/57e65d66-e274-4e7b-a106-5758f91d11db" />

DELETE 메소드를 사용하며, PathVariable로 스터디 name을 받습니다.

- 유저 삭제 API 와 비슷하게 약한 의존성 -> 강한 의존성 순으로 엔티티를 삭제합니다.
1. AssignmentSubmission 삭제
2. PlanComment 삭제
3. Plan 삭제
4. Attendance 삭제
5. StudyActivity 삭제
6. GroupMember 삭제
7. StudyGroup 삭제

참고로 Mock 데이터가 부족하여 운영단계에서 계속 수정해나가야 할 것 같습니다...
LAZY 로딩으로 인한 N+1 문제 발생시 FETCH JOIN을 사용하도록 쿼리 수정 예정입니다.

## 테스트

1. 스터디 그룹 전체 SELECT
<img width="1470" height="920" alt="스크린샷 2025-09-22 오후 6 46 42" src="https://github.com/user-attachments/assets/b40c5c77-5f02-4faa-8c20-34383f3a243e" />

2. "라스트어어어디" 라는 이름을 가진 스터디 그룹 MOCK 데이터 삭제
<img width="1260" height="946" alt="스크린샷 2025-09-22 오후 6 47 12" src="https://github.com/user-attachments/assets/7bdd6203-50dd-4a2b-8ee8-acf97ebf0af3" />
<img width="1470" height="920" alt="스크린샷 2025-09-22 오후 6 47 24" src="https://github.com/user-attachments/assets/d30465fb-9ae6-493f-bb5e-946627cc80eb" />
<img width="1350" height="197" alt="스크린샷 2025-09-22 오후 6 48 02" src="https://github.com/user-attachments/assets/0d5df8f5-f299-487d-a081-119b4dead1af" />


