### PR TITLE
Fix: 스터디 활동 글 다중 이미지 처리

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/StudyGroupController.java
+++ b/src/main/java/com/mjsec/lms/controller/StudyGroupController.java
@@ -96,7 +96,7 @@ public class StudyGroupController {
     public ResponseEntity<SuccessResponse<StudyActivityResponse>> createStudyActivity(
             @PathVariable Long groupId,
             @Valid @RequestPart("studyActivityDto") StudyActivityDto studyActivityDto,
-            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
             Authentication authentication
     ){
         log.info("Creating study activity for group: {}", groupId);
@@ -104,9 +104,13 @@ public class StudyGroupController {
         // JwtFilter에서 설정한 studentNumber를 가져옴
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();
 
-        validationUtils.validateActivityContent(studyActivityDto.getTitle(), studyActivityDto.getContent());
+        validationUtils.validateActivityContentWithImages(
+                studyActivityDto.getTitle(),
+                studyActivityDto.getContent(),
+                images
+        );
 
-        StudyActivityResponse studyActivityResponse = studyGroupService.createStudyActivity(groupId, currentUserStudentNumber, studyActivityDto, image);
+        StudyActivityResponse studyActivityResponse = studyGroupService.createStudyActivity(groupId, currentUserStudentNumber, studyActivityDto, images);
 
         return ResponseEntity.ok(
                 SuccessResponse.of(
@@ -122,7 +126,7 @@ public class StudyGroupController {
             @PathVariable Long groupId,
             @PathVariable Long activityId,
             @Valid @RequestPart("studyActivityDto") StudyActivityDto studyActivityDto,
-            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
             Authentication authentication) {
 
         log.info("Updating study activity: {} for group: {}", activityId, groupId);
@@ -130,10 +134,14 @@ public class StudyGroupController {
         Long currentUserStudentNumber = (Long) authentication.getPrincipal();
 
         validationUtils.validateActivityBelongsToGroup(activityId, groupId); // 연관관계 검증
-        validationUtils.validateActivityContent(studyActivityDto.getTitle(), studyActivityDto.getContent()); // 내용 검증
+        validationUtils.validateActivityContentWithImages(
+                studyActivityDto.getTitle(),
+                studyActivityDto.getContent(),
+                images
+        );// 내용 검증
 
         StudyActivityResponse studyActivityResponse = studyGroupService.updateStudyActivity(
-                groupId, activityId, currentUserStudentNumber, studyActivityDto, image);
+                groupId, activityId, currentUserStudentNumber, studyActivityDto, images);
 
         return ResponseEntity.ok(
                 SuccessResponse.of(

--- a/src/main/java/com/mjsec/lms/domain/StudyActivity.java
+++ b/src/main/java/com/mjsec/lms/domain/StudyActivity.java
@@ -34,8 +34,8 @@ public class StudyActivity extends BaseEntity{
     @Column(name="week", nullable = false, length = 50)
     private String week;
 
-    @Column(name = "image_url", columnDefinition = "TEXT")
-    private String imageUrl;
+    @Column(name = "image_urls", columnDefinition = "JSON")
+    private String imageUrls;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id")

--- a/src/main/java/com/mjsec/lms/dto/SimpleStudyActivityResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/SimpleStudyActivityResponse.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Builder
@@ -15,7 +16,7 @@ public class SimpleStudyActivityResponse {
 
     private String week;
 
-    private String imageUrl;
+    private List<String> imageUrls;
 
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/mjsec/lms/dto/StudyActivityDto.java
+++ b/src/main/java/com/mjsec/lms/dto/StudyActivityDto.java
@@ -21,5 +21,5 @@ public class StudyActivityDto {
     @Pattern(regexp = "^\\d{1,2}주차$", message = "주차는 'N주차' 형식이어야 합니다")
     private String week;
 
-    private String imageUrl;
+    private List<String> imageUrls;
 }

--- a/src/main/java/com/mjsec/lms/dto/StudyActivityResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/StudyActivityResponse.java
@@ -21,7 +21,7 @@ public class StudyActivityResponse {
 
     private String week;
 
-    private String imageUrl;
+    private List<String> imageUrls;
 
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/mjsec/lms/service/FileService.java
+++ b/src/main/java/com/mjsec/lms/service/FileService.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -29,6 +30,8 @@ public class FileService {
     @Value("${file.upload.max-size:10485760}") // 10MB
     private long maxFileSize;
 
+    private static final int MAX_IMAGE_COUNT = 5;
+
     // 허용되는 이미지 파일 타입 목록
     private final List<String> allowedImageTypes = Arrays.asList(
             "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"
@@ -43,6 +46,99 @@ public class FileService {
         } catch (IOException e) {
             log.error("Could not create upload directory: {}", uploadPath, e);
         }
+    }
+
+    // ========== 다중 이미지 처리 메서드들 ==========
+
+    // 다중 이미지 업로드 메서드
+    public List<String> uploadMultipleImages(List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
+            log.debug("No files provided for upload");
+            return new ArrayList<>();
+        }
+
+        // 이미지 개수 제한 검증
+        if (files.size() > MAX_IMAGE_COUNT) {
+            log.warn("Too many images provided: {} (max: {})", files.size(), MAX_IMAGE_COUNT);
+            throw new RestApiException(ErrorCode.TOO_MANY_IMAGES);
+        }
+
+        List<String> uploadedUrls = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            // 빈 파일 스킵
+            if (file.isEmpty()) {
+                log.debug("Skipping empty file");
+                continue;
+            }
+
+            String uploadedUrl = uploadImage(file);
+            uploadedUrls.add(uploadedUrl);
+        }
+
+        log.info("Successfully uploaded {} images", uploadedUrls.size());
+        return uploadedUrls;
+    }
+
+    // 다중 이미지 업데이트
+    public List<String> updateMultipleImages(List<String> currentImageUrls, List<MultipartFile> newImages,
+                                             String entityName, Long entityId) {
+
+        log.info("Updating multiple images for {}: {} - Current: {}, New: {}",
+                entityName, entityId,
+                currentImageUrls != null ? currentImageUrls.size() : 0,
+                newImages != null ? newImages.size() : 0);
+
+        //기존 이미지들 삭제
+        if (currentImageUrls != null && !currentImageUrls.isEmpty()) {
+            for (String imageUrl : currentImageUrls) {
+                try {
+                    deleteImage(imageUrl);
+                    log.debug("Previous image deleted successfully: {}", imageUrl);
+                } catch (Exception e) {
+                    log.warn("Failed to delete previous image: {}, but continuing", imageUrl, e);
+                }
+            }
+            log.info("Deleted {} existing images for {}: {}", currentImageUrls.size(), entityName, entityId);
+        }
+
+        //새 이미지가 제공된 경우 업로드
+        if (newImages != null && !newImages.isEmpty()) {
+            try {
+                List<String> newImageUrls = uploadMultipleImages(newImages);
+                log.info("New images uploaded successfully for {}: {} - {} images",
+                        entityName, entityId, newImageUrls.size());
+                return newImageUrls;
+            } catch (Exception e) {
+                log.error("Failed to upload new images for {}: {}", entityName, entityId, e);
+                // 새 이미지 업로드 실패시 예외를 다시 던져서 트랜잭션 롤백 유도
+                throw e;
+            }
+        }
+
+        //새 이미지가 없으면 빈 리스트 반환 (기존 이미지들은 이미 삭제됨)
+        log.info("No new images provided for {}: {}, all existing images deleted", entityName, entityId);
+        return new ArrayList<>();
+    }
+
+    // 다중 이미지 삭제 메서드
+    public void deleteMultipleImages(List<String> imageUrls) {
+        if (imageUrls == null || imageUrls.isEmpty()) {
+            log.debug("No images to delete");
+            return;
+        }
+
+        int deletedCount = 0;
+        for (String imageUrl : imageUrls) {
+            try {
+                deleteImage(imageUrl);
+                deletedCount++;
+            } catch (Exception e) {
+                log.warn("Failed to delete image: {}, continuing with others", imageUrl, e);
+            }
+        }
+
+        log.info("Deleted {}/{} images successfully", deletedCount, imageUrls.size());
     }
 
     // 이미지 파일을 업로드하고 웹에서 접근 가능한 URL을 반환하는 메서드

--- a/src/main/java/com/mjsec/lms/service/JwtService.java
+++ b/src/main/java/com/mjsec/lms/service/JwtService.java
@@ -3,10 +3,7 @@ package com.mjsec.lms.service;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Jwts.SIG;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 

--- a/src/main/java/com/mjsec/lms/service/StudyGroupService.java
+++ b/src/main/java/com/mjsec/lms/service/StudyGroupService.java
@@ -6,6 +6,7 @@ import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.repository.*;
 import com.mjsec.lms.type.ErrorCode;
 import com.mjsec.lms.type.GroupMemberRole;
+import com.mjsec.lms.util.JsonArrayUtils;
 import com.mjsec.lms.util.ValidationUtils;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ public class StudyGroupService {
     private final AttendanceRepository attendanceRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final FileService fileService;
+    private final JsonArrayUtils jsonArrayUtils;
 
     StudyGroupService(StudyGroupRepository studyGroupRepository,
                       ValidationUtils validationUtils,
@@ -35,7 +37,8 @@ public class StudyGroupService {
                       UserRepository userRepository,
                       AttendanceRepository attendanceRepository,
                       GroupMemberRepository groupMemberRepository,
-                      FileService fileService){
+                      FileService fileService,
+                      JsonArrayUtils jsonArrayUtils) {
 
         this.studyGroupRepository = studyGroupRepository;
         this.validationUtils = validationUtils;
@@ -44,6 +47,7 @@ public class StudyGroupService {
         this.attendanceRepository = attendanceRepository;
         this.groupMemberRepository = groupMemberRepository;
         this.fileService = fileService;
+        this.jsonArrayUtils = jsonArrayUtils;
     }
 
     //스터디 그룹 멤버 전체 반환
@@ -97,7 +101,7 @@ public class StudyGroupService {
     //스터디 활동 글 + 출석체크 설정하기
     @Transactional
     public StudyActivityResponse createStudyActivity(Long groupId, Long currentUserStudentNumber,
-                                                     StudyActivityDto studyActivityDto, MultipartFile image) {
+                                                     StudyActivityDto studyActivityDto, List<MultipartFile> images) {
 
         log.info("createStudyActivity called for group: {} by user: {}", groupId, currentUserStudentNumber);
 
@@ -112,10 +116,12 @@ public class StudyGroupService {
         validationUtils.validateActivityContent(studyActivityDto.getTitle(), studyActivityDto.getContent());
 
         // 이미지가 있으면 업로드
-        if (image != null && !image.isEmpty()) {
-            String imageUrl = fileService.uploadImage(image);
-            studyActivityDto.setImageUrl(imageUrl);
+        List<String> imageUrls = null;
+        if (images != null && !images.isEmpty()) {
+            imageUrls = fileService.uploadMultipleImages(images);
+            log.info("Uploaded {} images for new study activity", imageUrls.size());
         }
+        studyActivityDto.setImageUrls(imageUrls);
 
         StudyActivity savedStudyActivity = createStudyActivityData(groupId, studyActivityDto,user);
         List<Attendance> attendanceList = createAttendanceListData(savedStudyActivity, studyActivityDto);
@@ -128,7 +134,7 @@ public class StudyGroupService {
     //스터디 활동 글 수정하기
     @Transactional
     public StudyActivityResponse updateStudyActivity(Long groupId, Long activityId,
-                                                     Long currentUserStudentNumber, StudyActivityDto studyActivityDto, MultipartFile image) {
+                                                     Long currentUserStudentNumber, StudyActivityDto studyActivityDto, List<MultipartFile> images) {
 
         log.info("updateStudyActivity called for activity: {} in group: {} by user: {}",
                 activityId, groupId, currentUserStudentNumber);
@@ -147,7 +153,7 @@ public class StudyGroupService {
         validationUtils.validateDuplicateWeekForUpdate(studyGroup, studyActivityDto.getWeek(), activityId);
 
         // 이미지 처리 로직
-        handleImageUpdate(studyActivity, image, studyActivityDto);
+        handleMultipleImageUpdate(studyActivity, images, studyActivityDto);
 
         // 다른 필드들 업데이트
         updateStudyActivityData(studyActivity, studyActivityDto);
@@ -191,14 +197,13 @@ public class StudyGroupService {
         validationUtils.validateActivityOwnership(studyActivity, user.getUserId()); // 소유권 검증
 
         // 이미지가 있다면 파일 시스템에서 삭제
-        if (studyActivity.getImageUrl() != null && !studyActivity.getImageUrl().trim().isEmpty()) {
+        List<String> imageUrls = getImageUrlsFromEntity(studyActivity);
+        if (!imageUrls.isEmpty()) {
             try {
-                fileService.deleteImage(studyActivity.getImageUrl());
-                log.info("Image file deleted successfully: {}", studyActivity.getImageUrl());
+                fileService.deleteMultipleImages(imageUrls);
+                log.info("Multiple image files deleted successfully: {} images", imageUrls.size());
             } catch (Exception e) {
-                // 이미지 삭제 실패해도 활동 글 삭제는 계속 진행
-                log.warn("Failed to delete image file: {}, but continuing with activity deletion",
-                        studyActivity.getImageUrl(), e);
+                log.warn("Failed to delete some image files, but continuing with activity deletion", e);
             }
         }
 
@@ -265,20 +270,35 @@ public class StudyGroupService {
     그 외 Private 메서드
      */
 
-    //이미지 처리를 위한 별도 메서드
-    private void handleImageUpdate(StudyActivity studyActivity, MultipartFile newImage, StudyActivityDto dto) {
-        String newImageUrl = fileService.updateImage(
-                studyActivity.getImageUrl(),
-                newImage,
+    private void handleMultipleImageUpdate(StudyActivity studyActivity, List<MultipartFile> newImages, StudyActivityDto dto) {
+        List<String> currentImageUrls = getImageUrlsFromEntity(studyActivity);
+
+        // FileService의 updateMultipleImages 사용 - null이면 기존 이미지들 모두 삭제
+        List<String> newImageUrls = fileService.updateMultipleImages(
+                currentImageUrls,
+                newImages,
                 "StudyActivity",
                 studyActivity.getActivityId()
         );
 
-        // 이미지 URL이 변경된 경우에만 저장
-        if (!Objects.equals(studyActivity.getImageUrl(), newImageUrl)) {
-            studyActivity.setImageUrl(newImageUrl);
-            studyActivityRepository.save(studyActivity);
-        }
+        // 엔티티에 새로운 이미지 URL들 설정 - JsonArrayUtils 사용
+        setImageUrlsToEntity(studyActivity, newImageUrls);
+        dto.setImageUrls(newImageUrls); // DTO에도 설정
+        studyActivityRepository.save(studyActivity);
+
+        log.info("Multiple images updated for activity {}: {} images",
+                studyActivity.getActivityId(), newImageUrls.size());
+    }
+
+    // StudyActivity 엔티티에서 이미지 URL 리스트 추출
+    private List<String> getImageUrlsFromEntity(StudyActivity studyActivity) {
+        return jsonArrayUtils.parseStringArray(studyActivity.getImageUrls());
+    }
+
+    // StudyActivity 엔티티에 이미지 URL 리스트 설정
+    private void setImageUrlsToEntity(StudyActivity studyActivity, List<String> imageUrls) {
+        String jsonString = jsonArrayUtils.toStringArray(imageUrls);
+        studyActivity.setImageUrls(jsonString);
     }
 
     // 출석체크 데이터 업데이트 메서드 (전체 삭제 후 재생성)
@@ -305,7 +325,7 @@ public class StudyGroupService {
                             .studyActivity(studyActivity)
                             .type(attendanceDto.getType())
                             .week(studyActivity.getWeek())
-                            .attendanceDate(LocalDate.now()) // 수정 시점의 날짜로 업데이트
+                            .attendanceDate(LocalDate.now())
                             .build())
                     .collect(Collectors.toList());
 
@@ -334,8 +354,11 @@ public class StudyGroupService {
                 .studyGroup(studyGroupRepository.findById(groupId).orElseThrow())
                 .week(studyActivityDto.getWeek())
                 .creator(user)
-                .imageUrl(studyActivityDto.getImageUrl())
                 .build();
+
+        if (studyActivityDto.getImageUrls() != null) {
+            setImageUrlsToEntity(studyActivity, studyActivityDto.getImageUrls());
+        }
 
         return studyActivityRepository.save(studyActivity);
     }
@@ -408,7 +431,7 @@ public class StudyGroupService {
                 .title(studyActivity.getTitle())
                 .content(studyActivity.getContent())
                 .week(studyActivity.getWeek())
-                .imageUrl(studyActivity.getImageUrl())
+                .imageUrls(getImageUrlsFromEntity(studyActivity))
                 .studyAttendanceDtoList(studyAttendanceDtoList)
                 .createdAt(studyActivity.getCreatedAt())
                 .updatedAt(studyActivity.getUpdatedAt())
@@ -423,7 +446,7 @@ public class StudyGroupService {
                         .activityId(activity.getActivityId())
                         .title(activity.getTitle())
                         .week(activity.getWeek())
-                        .imageUrl(activity.getImageUrl())
+                        .imageUrls(getImageUrlsFromEntity(activity))
                         .createdAt(activity.getCreatedAt())
                         .build())
                 .collect(Collectors.toList());

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -113,7 +113,8 @@ public enum ErrorCode {
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지 파일을 찾을 수 없습니다."),
     UNSUPPORTED_IMAGE_TYPE(HttpStatus.BAD_REQUEST,  "지원하지 않는 이미지 파일 형식입니다."),
     IMAGE_NOT_READABLE(HttpStatus.INTERNAL_SERVER_ERROR,  "이미지 파일을 읽을 수 없습니다."),
-    IMAGE_LOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 로딩 중 오류가 발생했습니다.")
+    IMAGE_LOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 로딩 중 오류가 발생했습니다."),
+    TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "이미지는 최대 5개까지만 업로드할 수 있습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/mjsec/lms/util/JsonArrayUtils.java
+++ b/src/main/java/com/mjsec/lms/util/JsonArrayUtils.java
@@ -1,0 +1,189 @@
+package com.mjsec.lms.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Slf4j
+public class JsonArrayUtils {
+
+    // JSON 배열 문자열을 String List로 변환
+    // @param jsonArray JSON 배열 형태의 문자열 (예: ["url1", "url2", "url3"])
+    // @return String 리스트, 파싱 실패 시 빈 리스트 반환
+    public List<String> parseStringArray(String jsonArray) {
+        if (jsonArray == null || jsonArray.trim().isEmpty()) {
+            log.debug("JSON array is null or empty, returning empty list");
+            return new ArrayList<>();
+        }
+
+        try {
+            return parseJsonStringArray(jsonArray.trim());
+        } catch (Exception e) {
+            log.warn("Failed to parse JSON array: {} - Error: {}", jsonArray, e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    // String List를 JSON 배열 문자열로 변환
+    // @param stringList 문자열 리스트
+    // @return JSON 배열 형태의 문자열, 비어있으면 null 반환
+    public String toStringArray(List<String> stringList) {
+        if (stringList == null || stringList.isEmpty()) {
+            log.debug("String list is null or empty, returning null");
+            return null;
+        }
+
+        try {
+            return buildJsonStringArray(stringList);
+        } catch (Exception e) {
+            log.error("Failed to convert list to JSON array: {} - Error: {}", stringList, e.getMessage());
+            return null;
+        }
+    }
+
+    // JSON 배열이 유효한 형식인지 검증
+    // @param jsonArray 검증할 JSON 배열 문자열
+    // @return 유효하면 true, 그렇지 않으면 false
+    public boolean isValidJsonArray(String jsonArray) {
+        if (jsonArray == null || jsonArray.trim().isEmpty()) {
+            return true; // null이나 빈 문자열은 유효한 것으로 간주
+        }
+
+        try {
+            String trimmed = jsonArray.trim();
+            if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) {
+                return false;
+            }
+
+            // 간단한 구문 검증 - 실제 파싱해보기
+            parseJsonStringArray(trimmed);
+            return true;
+        } catch (Exception e) {
+            log.debug("JSON array validation failed: {} - Error: {}", jsonArray, e.getMessage());
+            return false;
+        }
+    }
+
+    // JSON 배열의 요소 개수를 반환
+    public int getArrayLength(String jsonArray) {
+        List<String> parsed = parseStringArray(jsonArray);
+        return parsed.size();
+    }
+
+    // 두 JSON 배열이 같은 내용을 가지고 있는지 비교
+    // @return 같으면 true, 다르면 false
+    public boolean arraysEqual(String jsonArray1, String jsonArray2) {
+        List<String> list1 = parseStringArray(jsonArray1);
+        List<String> list2 = parseStringArray(jsonArray2);
+        return list1.equals(list2);
+    }
+
+    /*
+    private Methods
+     */
+
+    // 실제 JSON 배열 파싱 로직
+    // 간단한 구현으로 큰따옴표로 둘러싸인 문자열들을 콤마로 분리
+    private List<String> parseJsonStringArray(String jsonArray) {
+        List<String> result = new ArrayList<>();
+
+        if (!jsonArray.startsWith("[") || !jsonArray.endsWith("]")) {
+            throw new IllegalArgumentException("Invalid JSON array format: must start with [ and end with ]");
+        }
+
+        // 대괄호 제거
+        String content = jsonArray.substring(1, jsonArray.length() - 1).trim();
+
+        if (content.isEmpty()) {
+            return result; // 빈 배열
+        }
+
+        // 콤마로 분리하되, 큰따옴표 안의 콤마는 무시
+        List<String> tokens = splitRespectingQuotes(content);
+
+        for (String token : tokens) {
+            String cleanToken = token.trim();
+            if (!cleanToken.isEmpty()) {
+                // 큰따옴표 제거
+                if (cleanToken.startsWith("\"") && cleanToken.endsWith("\"") && cleanToken.length() >= 2) {
+                    cleanToken = cleanToken.substring(1, cleanToken.length() - 1);
+                }
+
+                // 빈 문자열이 아닌 경우만 추가
+                if (!cleanToken.isEmpty()) {
+                    result.add(cleanToken);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    // String List를 JSON 배열로 변환하는 실제 로직
+    private String buildJsonStringArray(List<String> stringList) {
+        StringBuilder sb = new StringBuilder("[");
+
+        for (int i = 0; i < stringList.size(); i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+
+            String value = stringList.get(i);
+            if (value == null) {
+                sb.append("null");
+            } else {
+                // JSON 문자열로 이스케이프 처리
+                String escapedValue = escapeJsonString(value);
+                sb.append("\"").append(escapedValue).append("\"");
+            }
+        }
+
+        sb.append("]");
+        return sb.toString();
+    }
+
+    // 큰따옴표를 고려하여 콤마로 문자열 분리
+    private List<String> splitRespectingQuotes(String content) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean insideQuotes = false;
+
+        for (int i = 0; i < content.length(); i++) {
+            char c = content.charAt(i);
+
+            if (c == '"') {
+                insideQuotes = !insideQuotes;
+                current.append(c);
+            } else if (c == ',' && !insideQuotes) {
+                // 큰따옴표 밖의 콤마이면 분리
+                result.add(current.toString());
+                current = new StringBuilder();
+            } else {
+                current.append(c);
+            }
+        }
+
+        // 마지막 토큰 추가
+        if (current.length() > 0) {
+            result.add(current.toString());
+        }
+
+        return result;
+    }
+
+    // JSON 문자열 이스케이프 처리
+    private String escapeJsonString(String input) {
+        if (input == null) {
+            return null;
+        }
+
+        return input.replace("\\", "\\\\")  // 백슬래시
+                .replace("\"", "\\\"")   // 큰따옴표
+                .replace("\n", "\\n")    // 개행
+                .replace("\r", "\\r")    // 캐리지 리턴
+                .replace("\t", "\\t");   // 탭
+    }
+}

--- a/src/main/java/com/mjsec/lms/util/ValidationUtils.java
+++ b/src/main/java/com/mjsec/lms/util/ValidationUtils.java
@@ -8,6 +8,7 @@ import com.mjsec.lms.type.GroupMemberRole;
 import com.mjsec.lms.type.UserRole;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -247,6 +248,20 @@ public class ValidationUtils {
             validateMaliciousContent(content);
             log.debug("Activity content validated successfully");
         }
+    }
+
+    // 활동 글 + 이미지 검사
+    public void validateActivityContentWithImages(String title, String content, List<MultipartFile> images) {
+        // 기존 텍스트 내용 검증
+        validateActivityContent(title, content);
+
+        // 이미지 개수 검증
+        if (images != null && images.size() > 5) {
+            log.warn("Too many images provided: {} (max: 5)", images.size());
+            throw new RestApiException(ErrorCode.TOO_MANY_IMAGES);
+        }
+
+        log.debug("Activity content and images validated successfully");
     }
 
     // ========== 복합 접근 검증 ==========


### PR DESCRIPTION
### 스터디 활동 글 다중 이미지 처리

변경사항
* 활동 글에 최대 사진 5개까지 올릴 수 있게 됨.
* 활동 글 수정시 이미지가 등록되지 않는 경우 원래 있던 활동 글 이미지가 삭제됨. (uploads 폴더 내에 있는 이미지까지 삭제되는 구조)


### 테스트

<img width="724" height="797" alt="image" src="https://github.com/user-attachments/assets/dc22dc11-82a8-4af4-bb91-5380b22026e6" />

<img width="327" height="194" alt="image" src="https://github.com/user-attachments/assets/7cec6cc0-a7d3-4304-895c-d1b3b8fcf174" />

이미지도 잘 올라감

이제 수정해보겠슴

<img width="500" height="803" alt="image" src="https://github.com/user-attachments/assets/2a05f096-cf69-4fcc-9540-5ab2365f7b3a" />

굳

사진 갯수에 맞게 수정됨

원래 올렸던 사진 2개 → 아예 다른 2개 사진으로 변경시 원래 올렸던 사진 2개 삭제되고 아예 다른 2개 사진으로 uploads 폴더에 등록됨.

원래 올렸던 사진 2개 → 아예 다른 1개 사진으로 변경시 원래 올렸던 사진 2개 삭제되고 아예 다른 1개 사진으로 uploads 폴더에 등록됨.

이미지를 등록하지 않은 경우, imageUrls 가 빈 배열로 바뀌면서 원래 있던 사진들 삭제됨.

**→ 즉 수정되는 사진에 따라 원본 사진들이 변하는 구조가 됨**

<img width="400" height="347" alt="image" src="https://github.com/user-attachments/assets/98ee7760-5362-4f53-b057-4c14b229e6f9" />

삭제도 잘 됨.

이제 LMS 기능 하나만 더 하면 내가 할 거 진짜진짜 끝남
더 시키면 그때는 제리가 아니고 치와와가 될 예정임
<img width="725" height="871" alt="image" src="https://github.com/user-attachments/assets/ae8a8215-d605-4991-aa91-e313659e92c3" />
