### PR TITLE
Feat/assign status

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/AssignmentController.java
+++ b/src/main/java/com/mjsec/lms/controller/AssignmentController.java
@@ -371,27 +371,6 @@ public class AssignmentController {
         );
     }
 
-    //멘토용 피드백 대기 중인 과제 조회 API
-    @GetMapping("/{groupId}/assignment/submit/{planId}/pending-feedback")
-    public ResponseEntity<SuccessResponse<List<SubmissionResponse>>> getPendingFeedbackSubmissions(
-            @PathVariable Long groupId,
-            @PathVariable Long planId,
-            Authentication authentication) {
-
-        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
-
-        // SUBMITTED 상태인 과제들 조회
-        List<SubmissionResponse> submissionResponseList = assignmentSubmissionService.getSubmissionsByStatus(
-                groupId, planId, SubmissionStatus.SUBMITTED, currentUserStudentNumber);
-
-        return ResponseEntity.ok(
-                SuccessResponse.of(
-                        ResponseMessage.PENDING_FEEDBACK_SUBMISSIONS_SUCCESS,
-                        submissionResponseList
-                )
-        );
-    }
-
     // 멘티용 수정 필요한 과제 조회 API <- 필요할까 싶기도 함 일단 추가함.
     @GetMapping("/{groupId}/assignment/submit/{planId}/revision-required")
     public ResponseEntity<SuccessResponse<List<SubmissionResponse>>> getRevisionRequiredSubmissions(

--- a/src/main/java/com/mjsec/lms/controller/AssignmentController.java
+++ b/src/main/java/com/mjsec/lms/controller/AssignmentController.java
@@ -6,6 +6,7 @@ import com.mjsec.lms.dto.*;
 import com.mjsec.lms.service.AssignmentSubmissionService;
 import com.mjsec.lms.service.PlanService;
 import com.mjsec.lms.type.ResponseMessage;
+import com.mjsec.lms.type.SubmissionStatus;
 import com.mjsec.lms.util.IpUtils;
 import com.mjsec.lms.util.ValidationUtils;
 import jakarta.servlet.http.HttpServletRequest;
@@ -291,7 +292,7 @@ public class AssignmentController {
             @PathVariable Long groupId,
             @PathVariable Long planId,
             @PathVariable Long submitId,
-            @RequestBody SubmissionFeedbackDto dto,
+            @Valid @RequestBody SubmissionFeedbackDto dto,
             Authentication authentication){
 
         // JwtFilter에서 설정한 studentNumber를 가져옴
@@ -313,7 +314,7 @@ public class AssignmentController {
             @PathVariable Long groupId,
             @PathVariable Long planId,
             @PathVariable Long submitId,
-            @RequestBody SubmissionFeedbackDto dto,
+            @Valid @RequestBody SubmissionFeedbackDto dto,
             Authentication authentication){
 
         // JwtFilter에서 설정한 studentNumber를 가져옴
@@ -323,7 +324,8 @@ public class AssignmentController {
 
         return ResponseEntity.ok(
                 SuccessResponse.of(
-                        ResponseMessage.FEEDBACK_UPDATE_SUCCESS
+                        ResponseMessage.FEEDBACK_UPDATE_SUCCESS,
+                        submissionFeedbackDto
                 )
         );
     }
@@ -344,6 +346,90 @@ public class AssignmentController {
         return ResponseEntity.ok(
                 SuccessResponse.of(
                         ResponseMessage.FEEDBACK_DELETE_SUCCESS
+                )
+        );
+    }
+
+    //과제 상태별 조회 API
+    @GetMapping("/{groupId}/assignment/submit/{planId}/status/{status}")
+    public ResponseEntity<SuccessResponse<List<SubmissionResponse>>> getSubmissionsByStatus(
+            @PathVariable Long groupId,
+            @PathVariable Long planId,
+            @PathVariable SubmissionStatus status,
+            Authentication authentication) {
+
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        List<SubmissionResponse> submissionResponseList = assignmentSubmissionService.getSubmissionsByStatus(
+                groupId, planId, status, currentUserStudentNumber);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.ASSIGNMENT_SUBMIT_CHECK_SUCCESS,
+                        submissionResponseList
+                )
+        );
+    }
+
+    //멘토용 피드백 대기 중인 과제 조회 API
+    @GetMapping("/{groupId}/assignment/submit/{planId}/pending-feedback")
+    public ResponseEntity<SuccessResponse<List<SubmissionResponse>>> getPendingFeedbackSubmissions(
+            @PathVariable Long groupId,
+            @PathVariable Long planId,
+            Authentication authentication) {
+
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        // SUBMITTED 상태인 과제들 조회
+        List<SubmissionResponse> submissionResponseList = assignmentSubmissionService.getSubmissionsByStatus(
+                groupId, planId, SubmissionStatus.SUBMITTED, currentUserStudentNumber);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.PENDING_FEEDBACK_SUBMISSIONS_SUCCESS,
+                        submissionResponseList
+                )
+        );
+    }
+
+    // 멘티용 수정 필요한 과제 조회 API <- 필요할까 싶기도 함 일단 추가함.
+    @GetMapping("/{groupId}/assignment/submit/{planId}/revision-required")
+    public ResponseEntity<SuccessResponse<List<SubmissionResponse>>> getRevisionRequiredSubmissions(
+            @PathVariable Long groupId,
+            @PathVariable Long planId,
+            Authentication authentication) {
+
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        // REVISION_REQUIRED 상태인 과제들 조회
+        List<SubmissionResponse> submissionResponseList = assignmentSubmissionService.getSubmissionsByStatus(
+                groupId, planId, SubmissionStatus.REVISION_REQUIRED, currentUserStudentNumber);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.REVISION_REQUIRED_SUBMISSIONS_SUCCESS,
+                        submissionResponseList
+                )
+        );
+    }
+
+    // 과제 상태 통계 조회 API (멘토용)
+    @GetMapping("/{groupId}/assignment/submit/{planId}/statistics")
+    public ResponseEntity<SuccessResponse<SubmissionStatisticsResponse>> getSubmissionStatistics(
+            @PathVariable Long groupId,
+            @PathVariable Long planId,
+            Authentication authentication) {
+
+        // JwtFilter에서 설정한 studentNumber를 가져옴
+        Long currentUserStudentNumber = (Long) authentication.getPrincipal();
+
+        SubmissionStatisticsResponse statistics = assignmentSubmissionService.getSubmissionStatistics(
+                groupId, planId, currentUserStudentNumber);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.SUBMISSION_STATISTICS_SUCCESS,
+                        statistics
                 )
         );
     }

--- a/src/main/java/com/mjsec/lms/domain/AssignmentSubmission.java
+++ b/src/main/java/com/mjsec/lms/domain/AssignmentSubmission.java
@@ -1,5 +1,6 @@
 package com.mjsec.lms.domain;
 
+import com.mjsec.lms.type.SubmissionStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -35,6 +36,11 @@ public class AssignmentSubmission extends BaseEntity {
     
     @Column(name = "feedback", columnDefinition = "TEXT")
     private String feedback;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    @Builder.Default
+    private SubmissionStatus status = SubmissionStatus.SUBMITTED;
 
     // 연관관계 매핑
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/mjsec/lms/dto/DetailSubmissionResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/DetailSubmissionResponse.java
@@ -1,5 +1,6 @@
 package com.mjsec.lms.dto;
 
+import com.mjsec.lms.type.SubmissionStatus;
 import lombok.Builder;
 import lombok.Data;
 
@@ -18,6 +19,8 @@ public class DetailSubmissionResponse {
     private String creatorName;
 
     private String feedback;
+
+    private SubmissionStatus status;
 
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/mjsec/lms/dto/SubmissionFeedbackDto.java
+++ b/src/main/java/com/mjsec/lms/dto/SubmissionFeedbackDto.java
@@ -1,5 +1,7 @@
 package com.mjsec.lms.dto;
 
+import com.mjsec.lms.type.SubmissionStatus;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,5 +14,7 @@ import lombok.NoArgsConstructor;
 public class SubmissionFeedbackDto {
 
     private String feedback;
-    
+
+    @NotNull(message = "과제 상태는 필수입니다.")
+    private SubmissionStatus status;
 }

--- a/src/main/java/com/mjsec/lms/dto/SubmissionResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/SubmissionResponse.java
@@ -1,5 +1,6 @@
 package com.mjsec.lms.dto;
 
+import com.mjsec.lms.type.SubmissionStatus;
 import lombok.Builder;
 import lombok.Data;
 
@@ -15,6 +16,8 @@ public class SubmissionResponse {
     private String content;
 
     private String creatorName;
+
+    private SubmissionStatus status;
 
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/mjsec/lms/dto/SubmissionStatisticsResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/SubmissionStatisticsResponse.java
@@ -1,0 +1,16 @@
+package com.mjsec.lms.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SubmissionStatisticsResponse {
+
+    private int totalMentees;           // 전체 멘티 수
+    private int submittedCount;         // 제출 완료 상태
+    private int completedCount;         // 과제 완료 상태
+    private int revisionRequiredCount;  // 수정 필요 상태
+    private int notSubmittedCount;      // 미제출 수
+
+}

--- a/src/main/java/com/mjsec/lms/repository/SubmissionRepository.java
+++ b/src/main/java/com/mjsec/lms/repository/SubmissionRepository.java
@@ -1,8 +1,8 @@
 package com.mjsec.lms.repository;
 
 import com.mjsec.lms.domain.AssignmentSubmission;
-import com.mjsec.lms.domain.StudyGroup;
 import com.mjsec.lms.domain.User;
+import com.mjsec.lms.type.SubmissionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -37,4 +37,17 @@ public interface SubmissionRepository extends JpaRepository<AssignmentSubmission
             "WHERE a.submitter.userId = :userId " +
             "AND a.plan.studyGroup.studyId = :studyId")
     List<Long> findIdsByUserIdAndStudyGroupId(@Param("userId") Long userId, @Param("studyId") Long studyId);
+
+    // 특정 과제의 특정 상태 제출물들 조회
+    List<AssignmentSubmission> findByPlanPlanIdAndStatus(Long planId, SubmissionStatus status);
+
+    // 특정 사용자의 특정 과제의 특정 상태 제출물들 조회
+    List<AssignmentSubmission> findByPlanPlanIdAndSubmitterUserIdAndStatus(Long planId, Long submitterUserId, SubmissionStatus status);
+
+    int countByPlanPlanIdAndStatus(Long planId, SubmissionStatus status);
+
+    // 특정 과제에 제출한 고유 제출자 수 조회 (미제출자 계산용)
+    @Query("SELECT COUNT(DISTINCT a.submitter.userId) FROM AssignmentSubmission a WHERE a.plan.planId = :planId")
+    int countDistinctSubmittersByPlanId(@Param("planId") Long planId);
+
 }

--- a/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
+++ b/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
@@ -178,6 +178,7 @@ public class AssignmentSubmissionService {
         validationUtils.validateMentorAccess(groupId, currentUserStudentNumber);
         validationUtils.validatePlanBelongsToGroup(planId, groupId);
         validationUtils.validateAssignmentSubmissionAllowed(planId);
+        validationUtils.validateSubmissionStatus(dto.getStatus());
 
         //피드백 내용 + 제출 상태 검증
         validationUtils.validateFeedbackContentAndStatus(dto.getFeedback(), dto.getStatus());
@@ -200,6 +201,7 @@ public class AssignmentSubmissionService {
         validationUtils.validateMentorAccess(groupId, currentUserStudentNumber);
         validationUtils.validatePlanBelongsToGroup(planId, groupId);
         validationUtils.validateAssignmentSubmissionAllowed(planId);
+        validationUtils.validateSubmissionStatus(dto.getStatus());
 
         validationUtils.validateFeedbackContentAndStatus(dto.getFeedback(), dto.getStatus());
 
@@ -241,6 +243,7 @@ public class AssignmentSubmissionService {
         validationUtils.validatePlanBelongsToGroup(planId, groupId);
         Plan plan = validationUtils.validatePlan(planId);
         validationUtils.validateAssignmentSubmissionAllowed(planId);
+        validationUtils.validateSubmissionStatus(status);
 
         // 역할 반한
         GroupMemberRole role = validationUtils.validateUserRole(user.getUserId(), groupId);

--- a/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
+++ b/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
@@ -3,14 +3,13 @@ package com.mjsec.lms.service;
 import com.mjsec.lms.domain.AssignmentSubmission;
 import com.mjsec.lms.domain.Plan;
 import com.mjsec.lms.domain.User;
-import com.mjsec.lms.dto.DetailSubmissionResponse;
-import com.mjsec.lms.dto.SubmissionDto;
-import com.mjsec.lms.dto.SubmissionFeedbackDto;
-import com.mjsec.lms.dto.SubmissionResponse;
+import com.mjsec.lms.dto.*;
 import com.mjsec.lms.exception.RestApiException;
+import com.mjsec.lms.repository.GroupMemberRepository;
 import com.mjsec.lms.repository.SubmissionRepository;
 import com.mjsec.lms.type.ErrorCode;
 import com.mjsec.lms.type.GroupMemberRole;
+import com.mjsec.lms.type.SubmissionStatus;
 import com.mjsec.lms.util.ValidationUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,11 +25,13 @@ public class AssignmentSubmissionService {
 
     private final ValidationUtils validationUtils;
     private final SubmissionRepository submissionRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
-    AssignmentSubmissionService(ValidationUtils validationUtils, SubmissionRepository submissionRepository){
+    AssignmentSubmissionService(ValidationUtils validationUtils, SubmissionRepository submissionRepository, GroupMemberRepository groupMemberRepository){
 
         this.validationUtils = validationUtils;
         this.submissionRepository = submissionRepository;
+        this.groupMemberRepository = groupMemberRepository;
     }
 
     // 과제 제출하기 (멘티만)
@@ -60,6 +61,7 @@ public class AssignmentSubmissionService {
                 .password(dto.getPassword())
                 .submitter(user)
                 .plan(plan)
+                .status(SubmissionStatus.SUBMITTED)
                 .submitterIp(ipAddress)
                 .build();
 
@@ -105,16 +107,7 @@ public class AssignmentSubmissionService {
         AssignmentSubmission assignmentSubmission = validationUtils.validateSubmissionAccess(planId, submitId);
         GroupMemberRole role = validationUtils.validateUserRole(user.getUserId(), groupId);
 
-        if(role == GroupMemberRole.MENTEE) {
-            if (!assignmentSubmission.getSubmitter().getUserId().equals(user.getUserId())) {
-                log.warn("User {} attempted to access submission {} which is not theirs",
-                        user.getUserId(), submitId);
-                throw new RestApiException(ErrorCode.UNAUTHORIZED_ACCESS_SUBMISSION);
-            }
-        }
-        else if(role == GroupMemberRole.MENTOR) {
-            log.info("Mentor {} accessing submission {}", user.getUserId(), submitId);
-        }
+        validationUtils.validateSubmissionAccessByStatus(assignmentSubmission, user.getUserId(), role);
 
         return createDetailSubmissionResponse(assignmentSubmission);
     }
@@ -137,9 +130,18 @@ public class AssignmentSubmissionService {
         AssignmentSubmission assignmentSubmission = validationUtils.validateSubmissionAccess(planId, submitId);
         validationUtils.validateSubmissionOwnership(assignmentSubmission, user.getUserId());
 
+        //수정 가능한 상태인지 확인
+        validationUtils.validateSubmissionStatusForUpdate(assignmentSubmission);
+
         // 내용 검증 강화
         if (dto.getContent() != null && !dto.getContent().trim().isEmpty()) {
             validationUtils.validateSubmissionContent(dto.getContent());
+        }
+
+        //수정 필요 상태에서 재제출 시 상태를 SUBMITTED로 변경
+        if (assignmentSubmission.getStatus() == SubmissionStatus.REVISION_REQUIRED) {
+            assignmentSubmission.setStatus(SubmissionStatus.SUBMITTED);
+            log.info("Status changed from REVISION_REQUIRED to SUBMITTED for submission: {}", submitId);
         }
 
         return updateSubmitData(assignmentSubmission, dto);
@@ -160,6 +162,8 @@ public class AssignmentSubmissionService {
         AssignmentSubmission assignmentSubmission = validationUtils.validateSubmissionAccess(planId, submitId);
         validationUtils.validateSubmissionOwnership(assignmentSubmission, user.getUserId());
 
+        validationUtils.validateSubmissionStatusForDelete(assignmentSubmission);
+
         submissionRepository.delete(assignmentSubmission);
         log.info("Assignment submission deleted successfully: {}", assignmentSubmission);
     }
@@ -174,10 +178,14 @@ public class AssignmentSubmissionService {
         validationUtils.validateMentorAccess(groupId, currentUserStudentNumber);
         validationUtils.validatePlanBelongsToGroup(planId, groupId);
         validationUtils.validateAssignmentSubmissionAllowed(planId);
-        validationUtils.validateFeedbackContent(dto.getFeedback()); // 피드백 내용 검증
+
+        //피드백 내용 + 제출 상태 검증
+        validationUtils.validateFeedbackContentAndStatus(dto.getFeedback(), dto.getStatus());
 
         AssignmentSubmission assignmentSubmission = validationUtils.validateSubmissionAccess(planId, submitId);
         validationUtils.validateFeedbackNotExists(assignmentSubmission);
+
+        validationUtils.validateSubmissionStatusForFeedback(assignmentSubmission);
 
         leaveFeedbackData(assignmentSubmission, dto);
     }
@@ -192,10 +200,13 @@ public class AssignmentSubmissionService {
         validationUtils.validateMentorAccess(groupId, currentUserStudentNumber);
         validationUtils.validatePlanBelongsToGroup(planId, groupId);
         validationUtils.validateAssignmentSubmissionAllowed(planId);
-        validationUtils.validateFeedbackContent(dto.getFeedback()); // 피드백 내용 검증 강화
+
+        validationUtils.validateFeedbackContentAndStatus(dto.getFeedback(), dto.getStatus());
 
         AssignmentSubmission assignmentSubmission = validationUtils.validateSubmissionAccess(planId, submitId);
         validationUtils.validateFeedbackExists(assignmentSubmission);
+
+        validationUtils.validateStatusTransition(assignmentSubmission.getStatus(), dto.getStatus());
 
         return updateFeedbackData(assignmentSubmission, dto);
     }
@@ -220,6 +231,70 @@ public class AssignmentSubmissionService {
         log.info("Feedback deleted successfully for submission: {}", assignmentSubmission.getSubmissionId());
     }
 
+    // 상태별 과제 제출 조회 메서드
+    @Transactional(readOnly = true)
+    public List<SubmissionResponse> getSubmissionsByStatus(Long groupId, Long planId, SubmissionStatus status, Long currentUserStudentNumber) {
+
+        log.info("getSubmissionsByStatus called for status: {}", status);
+
+        User user = validationUtils.validateBasicAccess(groupId, currentUserStudentNumber);
+        validationUtils.validatePlanBelongsToGroup(planId, groupId);
+        Plan plan = validationUtils.validatePlan(planId);
+        validationUtils.validateAssignmentSubmissionAllowed(planId);
+
+        // 역할 반한
+        GroupMemberRole role = validationUtils.validateUserRole(user.getUserId(), groupId);
+
+        List<AssignmentSubmission> submissions;
+
+        if (role == GroupMemberRole.MENTOR) {
+            // 멘토는 해당 과제의 모든 특정 상태 제출물 조회 가능
+            submissions = submissionRepository.findByPlanPlanIdAndStatus(planId, status);
+            log.info("Mentor {} retrieved {} submissions with status: {}", user.getUserId(), submissions.size(), status);
+        } else {
+            // 멘티는 자신의 특정 상태 제출물만 조회 가능
+            submissions = submissionRepository.findByPlanPlanIdAndSubmitterUserIdAndStatus(planId, user.getUserId(), status);
+            log.info("Mentee {} retrieved {} own submissions with status: {}", user.getUserId(), submissions.size(), status);
+        }
+
+        return submissions.stream()
+                .map(this::createSubmissionResponse)
+                .collect(Collectors.toList());
+    }
+
+    // 과제 제출 통계 조회 메서드 (멘토 전용)
+    @Transactional(readOnly = true)
+    public SubmissionStatisticsResponse getSubmissionStatistics(Long groupId, Long planId, Long currentUserStudentNumber) {
+
+        log.info("getSubmissionStatistics called");
+
+        // 멘토 권한 검증
+        validationUtils.validateMentorAccess(groupId, currentUserStudentNumber);
+        validationUtils.validatePlanBelongsToGroup(planId, groupId);
+        Plan plan = validationUtils.validatePlan(planId);
+        validationUtils.validateAssignmentSubmissionAllowed(planId);
+
+        // 해당 스터디 그룹의 전체 멘티 수 조회
+        int totalMentees = groupMemberRepository.findByStudyGroup_StudyIdAndRole(groupId, GroupMemberRole.MENTEE).size();
+
+        // 상태별 제출 수 조회
+        int submittedCount = submissionRepository.countByPlanPlanIdAndStatus(planId, SubmissionStatus.SUBMITTED);
+        int completedCount = submissionRepository.countByPlanPlanIdAndStatus(planId, SubmissionStatus.COMPLETED);
+        int revisionRequiredCount = submissionRepository.countByPlanPlanIdAndStatus(planId, SubmissionStatus.REVISION_REQUIRED);
+
+        // 미제출자 수 계산
+        int submittedMentees = submissionRepository.countDistinctSubmittersByPlanId(planId);
+        int notSubmittedCount = totalMentees - submittedMentees;
+
+        return SubmissionStatisticsResponse.builder()
+                .totalMentees(totalMentees)
+                .submittedCount(submittedCount)
+                .completedCount(completedCount)
+                .revisionRequiredCount(revisionRequiredCount)
+                .notSubmittedCount(notSubmittedCount)
+                .build();
+    }
+
     /**
     DTO 반환용 Method들
      */
@@ -235,12 +310,17 @@ public class AssignmentSubmissionService {
             throw new RestApiException(ErrorCode.FEEDBACK_CONTENT_REQUIRED);
         }
 
+        if (dto.getStatus() != null) {
+            submission.setStatus(dto.getStatus());
+        }
+
         submissionRepository.save(submission);
 
         log.info("Feedback updated successfully for submission: {}", submission.getSubmissionId());
 
         return SubmissionFeedbackDto.builder()
                 .feedback(submission.getFeedback())
+                .status(submission.getStatus())
                 .build();
     }
 
@@ -254,6 +334,7 @@ public class AssignmentSubmissionService {
             throw new RestApiException(ErrorCode.FEEDBACK_CONTENT_REQUIRED);
         }
 
+        submission.setStatus(dto.getStatus());
         submission.setUpdatedAt(LocalDateTime.now());
         submissionRepository.save(submission);
 
@@ -267,6 +348,7 @@ public class AssignmentSubmissionService {
                 .submissionId(assignmentSubmission.getSubmissionId())
                 .content(assignmentSubmission.getContent())
                 .creatorName(assignmentSubmission.getSubmitter().getName())
+                .status(assignmentSubmission.getStatus())
                 .createdAt(assignmentSubmission.getCreatedAt())
                 .build();
     }
@@ -282,10 +364,10 @@ public class AssignmentSubmissionService {
                 .updatedAt(assignmentSubmission.getUpdatedAt())
                 .password(assignmentSubmission.getPassword())
                 .feedback(assignmentSubmission.getFeedback())
+                .status(assignmentSubmission.getStatus())
                 .build();
     }
 
-    // 제출한 과제 내용을 수정
     private DetailSubmissionResponse updateSubmitData(AssignmentSubmission assignmentSubmission, SubmissionDto dto) {
 
         // 수정할 데이터가 없으면 예외
@@ -294,13 +376,23 @@ public class AssignmentSubmissionService {
             throw new RestApiException(ErrorCode.SUBMISSION_CONTENT_REQUIRED);
         }
 
+        SubmissionStatus originalStatus = assignmentSubmission.getStatus();
+        boolean contentChanged = false;
+
         if(dto.getContent() != null && !dto.getContent().trim().isEmpty()){
             validationUtils.validateSubmissionContent(dto.getContent());
             assignmentSubmission.setContent(dto.getContent());
+            contentChanged = true;
         }
 
         if(dto.getPassword() != null && !dto.getPassword().trim().isEmpty()){
             assignmentSubmission.setPassword(dto.getPassword());
+        }
+
+        if (contentChanged && originalStatus == SubmissionStatus.REVISION_REQUIRED) {
+            assignmentSubmission.setStatus(SubmissionStatus.SUBMITTED);
+            log.info("Status changed -> SUBMITTED for submission: {}",
+                    assignmentSubmission.getSubmissionId());
         }
 
         assignmentSubmission.setUpdatedAt(LocalDateTime.now());

--- a/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
+++ b/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
@@ -377,22 +377,20 @@ public class AssignmentSubmissionService {
         }
 
         SubmissionStatus originalStatus = assignmentSubmission.getStatus();
-        boolean contentChanged = false;
 
         if(dto.getContent() != null && !dto.getContent().trim().isEmpty()){
             validationUtils.validateSubmissionContent(dto.getContent());
             assignmentSubmission.setContent(dto.getContent());
-            contentChanged = true;
+
+            if (originalStatus == SubmissionStatus.REVISION_REQUIRED) {
+                assignmentSubmission.setStatus(SubmissionStatus.SUBMITTED);
+                log.info("Status changed -> SUBMITTED for submission: {}",
+                        assignmentSubmission.getSubmissionId());
+            }
         }
 
         if(dto.getPassword() != null && !dto.getPassword().trim().isEmpty()){
             assignmentSubmission.setPassword(dto.getPassword());
-        }
-
-        if (contentChanged && originalStatus == SubmissionStatus.REVISION_REQUIRED) {
-            assignmentSubmission.setStatus(SubmissionStatus.SUBMITTED);
-            log.info("Status changed -> SUBMITTED for submission: {}",
-                    assignmentSubmission.getSubmissionId());
         }
 
         assignmentSubmission.setUpdatedAt(LocalDateTime.now());

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -64,7 +64,8 @@ public enum ErrorCode {
     PLAN_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     COMMENT_TOO_LONG(HttpStatus.BAD_REQUEST, "댓글은 1000자 이하로 작성해주세요."),
     UNAUTHORIZED_COMMENT_ACCESS(HttpStatus.UNAUTHORIZED, "댓글을 수정/삭제할 권한이 없습니다."),
-
+    INVALID_SUBMISSION_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 과제 상태입니다."),
+    
     //과제 피드백
     FEEDBACK_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 피드백을 남겼습니다."),
     FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND,"피드백이 존재하지 않습니다."),

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -70,6 +70,10 @@ public enum ErrorCode {
     FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND,"피드백이 존재하지 않습니다."),
     FEEDBACK_CONTENT_REQUIRED(HttpStatus.NOT_FOUND, "과제 피드백 내용이 없습니다."),
     FEEDBACK_TOO_LONG(HttpStatus.BAD_REQUEST, "피드백은 2000자 이하로 작성해주세요."),
+    INVALID_SUBMISSION_STATUS_FOR_FEEDBACK(HttpStatus.BAD_REQUEST, "제출 완료 상태의 과제만 피드백을 남길 수 있습니다."),
+    INVALID_SUBMISSION_STATUS_FOR_UPDATE(HttpStatus.BAD_REQUEST, "수정 가능한 상태의 과제가 아닙니다."),
+    INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 상태 변경입니다."),
+    FEEDBACK_STATUS_REQUIRED(HttpStatus.BAD_REQUEST, "피드백과 함께 과제 상태를 결정해주세요."),
 
     //과제 제출
     SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "과제 제출 내역을 찾을 수 없습니다."),

--- a/src/main/java/com/mjsec/lms/type/ResponseMessage.java
+++ b/src/main/java/com/mjsec/lms/type/ResponseMessage.java
@@ -43,6 +43,9 @@ public enum ResponseMessage {
     COMMENT_DELETE_SUCCESS("댓글 삭제 성공"),
     FEEDBACK_UPDATE_SUCCESS("과제 피드백 수정 성공"),
     FEEDBACK_DELETE_SUCCESS("과제 피드백 삭제 성공"),
+    PENDING_FEEDBACK_SUBMISSIONS_SUCCESS("피드백 대기 중인 과제 조회 성공"),
+    REVISION_REQUIRED_SUBMISSIONS_SUCCESS("수정 필요한 과제 조회 성공"),
+    SUBMISSION_STATISTICS_SUCCESS("과제 제출 통계 조회 성공"),
 
     // 계획
     PLAN_CREATE_SUCCESS("계획 등록 성공"),

--- a/src/main/java/com/mjsec/lms/type/SubmissionStatus.java
+++ b/src/main/java/com/mjsec/lms/type/SubmissionStatus.java
@@ -1,0 +1,8 @@
+package com.mjsec.lms.type;
+
+public enum SubmissionStatus {
+    SUBMITTED,
+    COMPLETED,
+    REVISION_REQUIRED
+
+}

--- a/src/main/java/com/mjsec/lms/util/ValidationUtils.java
+++ b/src/main/java/com/mjsec/lms/util/ValidationUtils.java
@@ -5,6 +5,7 @@ import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.repository.*;
 import com.mjsec.lms.type.ErrorCode;
 import com.mjsec.lms.type.GroupMemberRole;
+import com.mjsec.lms.type.SubmissionStatus;
 import com.mjsec.lms.type.UserRole;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -264,6 +265,91 @@ public class ValidationUtils {
         log.debug("Activity content and images validated successfully");
     }
 
+    // 피드백을 남길 수 있는 상태인지 검증
+    public void validateSubmissionStatusForFeedback(AssignmentSubmission submission) {
+        if (submission.getStatus() != SubmissionStatus.SUBMITTED) {
+            log.warn("Cannot leave feedback for submission {} in status: {}",
+                    submission.getSubmissionId(), submission.getStatus());
+            throw new RestApiException(ErrorCode.INVALID_SUBMISSION_STATUS_FOR_FEEDBACK);
+        }
+    }
+
+    // 피드백 DTO의 상태 값 검증
+    public void validateFeedbackStatus(SubmissionStatus status) {
+        if (status == null) {
+            throw new RestApiException(ErrorCode.FEEDBACK_STATUS_REQUIRED);
+        }
+
+        // 피드백 시에는 COMPLETED 또는 REVISION_REQUIRED만 가능
+        if (status != SubmissionStatus.COMPLETED && status != SubmissionStatus.REVISION_REQUIRED) {
+            log.warn("Invalid feedback status: {}. Only COMPLETED or REVISION_REQUIRED allowed", status);
+            throw new RestApiException(ErrorCode.INVALID_STATUS_TRANSITION);
+        }
+    }
+
+    // 과제를 수정할 수 있는 상태인지 검증 (멘티용)
+    public void validateSubmissionStatusForUpdate(AssignmentSubmission submission) {
+        // 제출 완료 상태이거나 수정 필요 상태일 때만 수정 가능
+        if (submission.getStatus() != SubmissionStatus.SUBMITTED &&
+                submission.getStatus() != SubmissionStatus.REVISION_REQUIRED) {
+            log.warn("Cannot update submission {} in status: {}",
+                    submission.getSubmissionId(), submission.getStatus());
+            throw new RestApiException(ErrorCode.INVALID_SUBMISSION_STATUS_FOR_UPDATE);
+        }
+    }
+
+    // 상태 전환이 유효한지 검증
+    public void validateStatusTransition(SubmissionStatus currentStatus, SubmissionStatus newStatus) {
+        boolean isValidTransition = false;
+
+        switch (currentStatus) {
+            case SUBMITTED:
+                // 제출 완료 -> 완료 또는 수정 필요
+                isValidTransition = (newStatus == SubmissionStatus.COMPLETED ||
+                        newStatus == SubmissionStatus.REVISION_REQUIRED);
+                break;
+
+            case REVISION_REQUIRED:
+                // 수정 필요 -> 제출 완료 (재제출 시)
+                isValidTransition = (newStatus == SubmissionStatus.SUBMITTED);
+                break;
+
+            case COMPLETED:
+                // 완료 -> 수정 필요 (피드백 수정 시에만)
+                isValidTransition = (newStatus == SubmissionStatus.REVISION_REQUIRED ||
+                        newStatus == SubmissionStatus.COMPLETED); // 피드백 수정
+                break;
+        }
+
+        if (!isValidTransition) {
+            log.warn("Invalid status transition from {} to {}", currentStatus, newStatus);
+            throw new RestApiException(ErrorCode.INVALID_STATUS_TRANSITION);
+        }
+    }
+
+    // 과제 제출 삭제 가능 상태 검증
+    public void validateSubmissionStatusForDelete(AssignmentSubmission submission) {
+        // 완료된 과제는 삭제 불가
+        if (submission.getStatus() == SubmissionStatus.COMPLETED) {
+            log.warn("Cannot delete completed submission: {}", submission.getSubmissionId());
+            throw new RestApiException(ErrorCode.INVALID_SUBMISSION_STATUS_FOR_UPDATE);
+        }
+    }
+
+    // 과제 상태에 따른 접근 권한 검증 (멘티가 자신의 과제에 접근할 때)
+    public void validateSubmissionAccessByStatus(AssignmentSubmission submission, Long userId, GroupMemberRole role) {
+        if (role == GroupMemberRole.MENTOR) {
+            return;
+        }
+
+        // 멘티는 자신의 과제만 접근 가능
+        if (!submission.getSubmitter().getUserId().equals(userId)) {
+            log.warn("User {} attempted to access submission {} which is not theirs",
+                    userId, submission.getSubmissionId());
+            throw new RestApiException(ErrorCode.UNAUTHORIZED_ACCESS_SUBMISSION);
+        }
+    }
+
     // ========== 복합 접근 검증 ==========
 
     // 기본 접근 검증 (사용자, 스터디 그룹 존재, 멤버십)
@@ -396,6 +482,11 @@ public class ValidationUtils {
         }
 
         validateMaliciousContent(content);
+    }
+
+    public void validateFeedbackContentAndStatus(String feedback, SubmissionStatus status) {
+        validateFeedbackContent(feedback);
+        validateFeedbackStatus(status);
     }
 
     // 피드백 내용 검증 강화

--- a/src/main/java/com/mjsec/lms/util/ValidationUtils.java
+++ b/src/main/java/com/mjsec/lms/util/ValidationUtils.java
@@ -327,6 +327,22 @@ public class ValidationUtils {
         }
     }
 
+    //과제 제출 상태 ENUM 타입 검증
+    public SubmissionStatus validateSubmissionStatus(SubmissionStatus status) {
+        String statusString = status.toString();
+
+        if (statusString == null || statusString.trim().isEmpty()) {
+            throw new RestApiException(ErrorCode.INVALID_SUBMISSION_STATUS);
+        }
+
+        try {
+            return SubmissionStatus.valueOf(statusString.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid submission status provided: {}", statusString);
+            throw new RestApiException(ErrorCode.INVALID_SUBMISSION_STATUS);
+        }
+    }
+
     // 과제 제출 삭제 가능 상태 검증
     public void validateSubmissionStatusForDelete(AssignmentSubmission submission) {
         // 완료된 과제는 삭제 불가


### PR DESCRIPTION
### 과제 제출 상태 추가

상태들
* 제출 완료 (SUBMITTED)
* 멘토 확인 후 과제 완료 ( COMPLETED)
* 멘토 확인 후 수정 필요 (REVISION_REQUIRED)

기본 로직
멘티가 과제 제출(제출 완료) -> 멘토가 피드백 후 상태 결정 -> 완료 / 수정 필요
수정 필요 상태일시 멘티가 수정 후 제출하면 다시 제출 완료 상태 변경됨 -> 피드백 수정 + 완료 / 수정 필요 상태 결정
-> 반복

**테스트**

과제 있는 계획 만듬
<img width="541" height="553" alt="image" src="https://github.com/user-attachments/assets/a37e6ea8-da09-4f43-aaf6-cd5eb1043d6b" />

멘티 2명이 과제를 제출함. (상태 SUBMITTED 로 바뀜)
<img width="540" height="562" alt="image" src="https://github.com/user-attachments/assets/adf4eae6-2559-4c37-aee8-a7acd42e61cc" />

과제 제출 확인
<img width="525" height="625" alt="image" src="https://github.com/user-attachments/assets/67c2b0b6-822c-407e-9f7b-37383445aae8" />

피드백을 남길 때 status 도 함께 보내도록 해서 과제 상태까지 변경이 가능합니다.
(변경 후 조회)
<img width="528" height="644" alt="image" src="https://github.com/user-attachments/assets/22731f25-2b33-4030-9827-5d5a11f5a583" />

멘티 두명은 각각
<img width="600" height="592" alt="image" src="https://github.com/user-attachments/assets/8bab9f2a-2d93-4c82-847c-3e67d2f8f768" />

<img width="626" height="565" alt="image" src="https://github.com/user-attachments/assets/baeb1c74-83d9-4321-b6c4-140f7f879267" />

이와 같이 기록이 잘 됨을 확인할 수 있습니다.

과제 수정이 필요한 멘티가 과제를 수정한다면 다시 SUBMITTED로 변경됩니다.
<img width="554" height="615" alt="image" src="https://github.com/user-attachments/assets/e794ecfd-bdaf-4926-9d7a-f890a2c88eb8" />

반대로 과제 제출 합격을 받은 경우엔, 더이상 제출한 내용을 수정할 수 없습니다.
<img width="598" height="368" alt="image" src="https://github.com/user-attachments/assets/2e15766e-5490-4fe6-83d1-59ad4c8c4348" />



또한 프론트엔드 측에서 필요할까 싶어서 

<img width="625" height="601" alt="image" src="https://github.com/user-attachments/assets/dadfb7f0-ad07-4b7f-9c9a-7aae99d188e0" />

각 제출 상태 기준 조회 기능과

<img width="496" height="463" alt="image" src="https://github.com/user-attachments/assets/9f852a80-edac-497f-8f25-d77cdee20885" />

통계를 만들긴 했는데...

통계는 좀 쓸모없을 거 같네요. 이건 필요하면 쓰십쇼 ?




