### PR TITLE
Fix: 이미지 파일 업로드 보안 강화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.12.3'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+	implementation 'org.apache.tika:tika-core:2.9.1'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/mjsec/lms/controller/AdminController.java
+++ b/src/main/java/com/mjsec/lms/controller/AdminController.java
@@ -9,6 +9,8 @@ import com.mjsec.lms.dto.UserAdminResponseDto;
 import com.mjsec.lms.service.AdminService;
 import com.mjsec.lms.type.ResponseMessage;
 import jakarta.validation.Valid;
+
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/mjsec/lms/domain/AssignmentSubmission.java
+++ b/src/main/java/com/mjsec/lms/domain/AssignmentSubmission.java
@@ -44,12 +44,6 @@ public class AssignmentSubmission extends BaseEntity {
     @Builder.Default
     private SubmissionStatus status = SubmissionStatus.SUBMITTED;
 
-    @Column(name = "created_at")
-    private ZonedDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private ZonedDateTime updatedAt;
-
     // 연관관계 매핑
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/mjsec/lms/domain/AssignmentSubmission.java
+++ b/src/main/java/com/mjsec/lms/domain/AssignmentSubmission.java
@@ -7,6 +7,8 @@ import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.ZonedDateTime;
+
 @Entity
 @Getter
 @Setter
@@ -41,6 +43,12 @@ public class AssignmentSubmission extends BaseEntity {
     @Column(name = "status", nullable = false, length = 20)
     @Builder.Default
     private SubmissionStatus status = SubmissionStatus.SUBMITTED;
+
+    @Column(name = "created_at")
+    private ZonedDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private ZonedDateTime updatedAt;
 
     // 연관관계 매핑
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/mjsec/lms/dto/DetailSubmissionResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/DetailSubmissionResponse.java
@@ -23,7 +23,7 @@ public class DetailSubmissionResponse {
 
     private SubmissionStatus status;
 
-    private ZonedDateTime createdAt;
+    private LocalDateTime createdAt;
 
-    private ZonedDateTime updatedAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/mjsec/lms/dto/DetailSubmissionResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/DetailSubmissionResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 @Data
 @Builder
@@ -22,7 +23,7 @@ public class DetailSubmissionResponse {
 
     private SubmissionStatus status;
 
-    private LocalDateTime createdAt;
+    private ZonedDateTime createdAt;
 
-    private LocalDateTime updatedAt;
+    private ZonedDateTime updatedAt;
 }

--- a/src/main/java/com/mjsec/lms/dto/SubmissionResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/SubmissionResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 //과제 제출 반환 Dto
 @Data
@@ -19,5 +20,5 @@ public class SubmissionResponse {
 
     private SubmissionStatus status;
 
-    private LocalDateTime createdAt;
+    private ZonedDateTime createdAt;
 }

--- a/src/main/java/com/mjsec/lms/dto/SubmissionResponse.java
+++ b/src/main/java/com/mjsec/lms/dto/SubmissionResponse.java
@@ -20,5 +20,5 @@ public class SubmissionResponse {
 
     private SubmissionStatus status;
 
-    private ZonedDateTime createdAt;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/mjsec/lms/service/AdminService.java
+++ b/src/main/java/com/mjsec/lms/service/AdminService.java
@@ -30,6 +30,8 @@ import com.mjsec.lms.type.GroupMemberRole;
 import com.mjsec.lms.type.UserRole;
 import com.mjsec.lms.type.StudyStatus;
 import jakarta.transaction.Transactional;
+
+import java.io.IOException;
 import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
+++ b/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
@@ -178,7 +178,7 @@ public class AssignmentSubmissionService {
         validationUtils.validateMentorAccess(groupId, currentUserStudentNumber);
         validationUtils.validatePlanBelongsToGroup(planId, groupId);
         validationUtils.validateAssignmentSubmissionAllowed(planId);
-        validationUtils.validateSubmissionStatus(dto.getStatus());
+        validationUtils.validateSubmissionStatus(dto.getStatus().toString());
 
         //피드백 내용 + 제출 상태 검증
         validationUtils.validateFeedbackContentAndStatus(dto.getFeedback(), dto.getStatus());
@@ -201,7 +201,7 @@ public class AssignmentSubmissionService {
         validationUtils.validateMentorAccess(groupId, currentUserStudentNumber);
         validationUtils.validatePlanBelongsToGroup(planId, groupId);
         validationUtils.validateAssignmentSubmissionAllowed(planId);
-        validationUtils.validateSubmissionStatus(dto.getStatus());
+        validationUtils.validateSubmissionStatus(dto.getStatus().toString());
 
         validationUtils.validateFeedbackContentAndStatus(dto.getFeedback(), dto.getStatus());
 
@@ -243,7 +243,7 @@ public class AssignmentSubmissionService {
         validationUtils.validatePlanBelongsToGroup(planId, groupId);
         Plan plan = validationUtils.validatePlan(planId);
         validationUtils.validateAssignmentSubmissionAllowed(planId);
-        validationUtils.validateSubmissionStatus(status);
+        validationUtils.validateSubmissionStatus(status.toString());
 
         // 역할 반한
         GroupMemberRole role = validationUtils.validateUserRole(user.getUserId(), groupId);

--- a/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
+++ b/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -57,7 +57,7 @@ public class AssignmentSubmissionService {
 
         AssignmentSubmission assignmentSubmission = AssignmentSubmission.builder()
                 .content(dto.getContent())
-                .createdAt(LocalDateTime.now())
+                .createdAt(ZonedDateTime.now())
                 .password(dto.getPassword())
                 .submitter(user)
                 .plan(plan)
@@ -227,7 +227,7 @@ public class AssignmentSubmissionService {
         validationUtils.validateFeedbackExists(assignmentSubmission);
 
         assignmentSubmission.setFeedback(null);
-        assignmentSubmission.setUpdatedAt(LocalDateTime.now());
+        assignmentSubmission.setUpdatedAt(ZonedDateTime.now());
         submissionRepository.save(assignmentSubmission);
 
         log.info("Feedback deleted successfully for submission: {}", assignmentSubmission.getSubmissionId());
@@ -307,7 +307,7 @@ public class AssignmentSubmissionService {
 
         if(dto.getFeedback() != null && !dto.getFeedback().trim().isEmpty()){
             submission.setFeedback(dto.getFeedback());
-            submission.setUpdatedAt(LocalDateTime.now());
+            submission.setUpdatedAt(ZonedDateTime.now());
         }
         else {
             throw new RestApiException(ErrorCode.FEEDBACK_CONTENT_REQUIRED);
@@ -338,7 +338,7 @@ public class AssignmentSubmissionService {
         }
 
         submission.setStatus(dto.getStatus());
-        submission.setUpdatedAt(LocalDateTime.now());
+        submission.setUpdatedAt(ZonedDateTime.now());
         submissionRepository.save(submission);
 
         log.info("Feedback saved successfully for submission: {}", submission.getSubmissionId());
@@ -396,7 +396,7 @@ public class AssignmentSubmissionService {
             assignmentSubmission.setPassword(dto.getPassword());
         }
 
-        assignmentSubmission.setUpdatedAt(LocalDateTime.now());
+        assignmentSubmission.setUpdatedAt(ZonedDateTime.now());
         submissionRepository.save(assignmentSubmission);
 
         log.info("Assignment submission updated successfully: {}", assignmentSubmission.getSubmissionId());

--- a/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
+++ b/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
+++ b/src/main/java/com/mjsec/lms/service/AssignmentSubmissionService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -57,7 +58,7 @@ public class AssignmentSubmissionService {
 
         AssignmentSubmission assignmentSubmission = AssignmentSubmission.builder()
                 .content(dto.getContent())
-                .createdAt(ZonedDateTime.now())
+                .createdAt(LocalDateTime.now())
                 .password(dto.getPassword())
                 .submitter(user)
                 .plan(plan)
@@ -227,7 +228,7 @@ public class AssignmentSubmissionService {
         validationUtils.validateFeedbackExists(assignmentSubmission);
 
         assignmentSubmission.setFeedback(null);
-        assignmentSubmission.setUpdatedAt(ZonedDateTime.now());
+        assignmentSubmission.setUpdatedAt(LocalDateTime.now());
         submissionRepository.save(assignmentSubmission);
 
         log.info("Feedback deleted successfully for submission: {}", assignmentSubmission.getSubmissionId());
@@ -307,7 +308,7 @@ public class AssignmentSubmissionService {
 
         if(dto.getFeedback() != null && !dto.getFeedback().trim().isEmpty()){
             submission.setFeedback(dto.getFeedback());
-            submission.setUpdatedAt(ZonedDateTime.now());
+            submission.setUpdatedAt(LocalDateTime.now());
         }
         else {
             throw new RestApiException(ErrorCode.FEEDBACK_CONTENT_REQUIRED);
@@ -338,7 +339,7 @@ public class AssignmentSubmissionService {
         }
 
         submission.setStatus(dto.getStatus());
-        submission.setUpdatedAt(ZonedDateTime.now());
+        submission.setUpdatedAt(LocalDateTime.now());
         submissionRepository.save(submission);
 
         log.info("Feedback saved successfully for submission: {}", submission.getSubmissionId());
@@ -396,7 +397,7 @@ public class AssignmentSubmissionService {
             assignmentSubmission.setPassword(dto.getPassword());
         }
 
-        assignmentSubmission.setUpdatedAt(ZonedDateTime.now());
+        assignmentSubmission.setUpdatedAt(LocalDateTime.now());
         submissionRepository.save(assignmentSubmission);
 
         log.info("Assignment submission updated successfully: {}", assignmentSubmission.getSubmissionId());

--- a/src/main/java/com/mjsec/lms/service/FileService.java
+++ b/src/main/java/com/mjsec/lms/service/FileService.java
@@ -2,6 +2,7 @@ package com.mjsec.lms.service;
 
 import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.type.ErrorCode;
+import com.mjsec.lms.util.FileUtils;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tika.Tika;
@@ -25,7 +26,6 @@ import java.util.*;
 @Slf4j
 public class FileService {
 
-    private static final int BUFFER_SIZE = 8192; // 8KB 청크 단위 처리
     private static final int MAX_HEADER_SIZE = 1024; // 헤더 검증용 최대 크기
     private static final double MAX_MEMORY_USAGE_RATIO = 0.8; // 최대 메모리 사용률 80%
 
@@ -34,25 +34,6 @@ public class FileService {
     // 파일 업로드 경로 설정값을 가져옴
     @Value("${file.upload.path:uploads/}")
     private String uploadPath;
-
-    // Apache Tika 인스턴스
-    private final Tika tika = new Tika();
-
-    // 이미지 파일 시그니처 (Magic Numbers)
-    private static final Map<String, byte[]> IMAGE_SIGNATURES = new HashMap<>();
-
-    static {
-        // JPEG
-        IMAGE_SIGNATURES.put("jpg", new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF});
-        // PNG
-        IMAGE_SIGNATURES.put("png", new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A});
-        // GIF
-        IMAGE_SIGNATURES.put("gif87", "GIF87a".getBytes());
-        IMAGE_SIGNATURES.put("gif89", "GIF89a".getBytes());
-        // WebP
-        IMAGE_SIGNATURES.put("webp_riff", "RIFF".getBytes());
-        IMAGE_SIGNATURES.put("webp_sig", "WEBP".getBytes());
-    }
 
     // 최대 파일 크기 설정 (기본값: 10MB)
     @Value("${file.upload.max-size:10485760}") // 10MB
@@ -65,16 +46,6 @@ public class FileService {
             "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"
     );
 
-    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList(
-            "jpg", "jpeg", "png", "gif", "webp"
-    );
-
-    private static final List<String> DANGEROUS_EXTENSIONS = Arrays.asList(
-            "jsp", "jspx", "php", "php3", "php4", "php5", "phtml",
-            "asp", "aspx", "ascx", "ashx", "asmx",
-            "exe", "dll", "com", "bat", "cmd", "sh", "bash",
-            "cgi", "pl", "py", "rb", "js", "jar", "war"
-    );
 
     // 스프링 빈 생성 후 실행되는 초기화 메서드
     @PostConstruct
@@ -197,7 +168,7 @@ public class FileService {
                 long usedMemory = memoryBean.getHeapMemoryUsage().getUsed();
                 long maxMemory = memoryBean.getHeapMemoryUsage().getMax();
                 double usageRatio = (double) usedMemory / maxMemory;
-                log.debug("Memory usage after file upload: {:.2f}%", usageRatio * 100);
+                log.debug("파일 업로드 후 메모리 상태: {:.2f}%", usageRatio * 100);
             }
         }
 
@@ -213,7 +184,7 @@ public class FileService {
         validateImageFileMemorySafe(file);
 
         // 고유한 파일명 생성
-        String fileName = generateUniqueFileName(file.getOriginalFilename());
+        String fileName = FileUtils.generateUniqueFileName(file.getOriginalFilename());
         String filePath = uploadPath + fileName;
 
         try {
@@ -290,75 +261,6 @@ public class FileService {
     /*
     ------- PRIVATE ----------
      */
-
-    // 파일 시그니처 검증 메서드
-    private boolean verifyImageSignature(byte[] fileBytes, String expectedExtension) {
-
-        if (fileBytes == null || fileBytes.length < 12) {
-            return false;
-        }
-
-        expectedExtension = expectedExtension.toLowerCase();
-
-        try {
-            // JPEG 검증
-            if (expectedExtension.equals("jpg") || expectedExtension.equals("jpeg")) {
-                return fileBytes[0] == (byte) 0xFF &&
-                        fileBytes[1] == (byte) 0xD8 &&
-                        fileBytes[2] == (byte) 0xFF;
-            }
-
-            // PNG 검증
-            if (expectedExtension.equals("png")) {
-                byte[] pngSignature = IMAGE_SIGNATURES.get("png");
-                for (int i = 0; i < pngSignature.length; i++) {
-                    if (fileBytes[i] != pngSignature[i]) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-
-            // GIF 검증
-            if (expectedExtension.equals("gif")) {
-                String header = new String(fileBytes, 0, 6);
-                return header.equals("GIF87a") || header.equals("GIF89a");
-            }
-
-            // WebP 검증
-            if (expectedExtension.equals("webp")) {
-                String riff = new String(fileBytes, 0, 4);
-                String webp = new String(fileBytes, 8, 4);
-                return riff.equals("RIFF") && webp.equals("WEBP");
-            }
-
-            return false;
-        } catch (Exception e) {
-            log.error("Error verifying image signature", e);
-            return false;
-        }
-    }
-
-    // 원본 파일명을 기반으로 고유한 파일명을 생성하는 메서드
-    private String generateUniqueFileName(String originalFileName) {
-
-        if (originalFileName == null || originalFileName.trim().isEmpty()) {
-            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
-        }
-
-        String extension = extractAndValidateExtension(originalFileName);
-
-        String safeFileName = UUID.randomUUID().toString() + "." + extension;
-
-        if (safeFileName.contains("..") || safeFileName.contains("/") || safeFileName.contains("\\")) {
-            log.error("Path traversal attempt in generated filename: {}", safeFileName);
-            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
-        }
-
-        log.info("Safe filename generated: {} -> {}", originalFileName, safeFileName);
-        return safeFileName;
-    }
-
     private void validateImageFileMemorySafe(MultipartFile file) {
 
         // 기본 검증
@@ -383,23 +285,23 @@ public class FileService {
         }
 
         // 확장자 추출 및 검증
-        String extension = extractAndValidateExtension(originalFilename);
+        String extension = FileUtils.extractAndValidateExtension(originalFilename);
 
         // 스트림 기반 파일 검증
         try (InputStream inputStream = new BufferedInputStream(file.getInputStream())) {
 
             // 헤더만 읽어서 Magic Number 검증 (메모리 효율적)
-            byte[] headerBytes = readHeader(inputStream, MAX_HEADER_SIZE);
+            byte[] headerBytes = FileUtils.readHeader(inputStream, MAX_HEADER_SIZE);
 
             // Magic Number 검증
-            if (!verifyImageSignature(headerBytes, extension)) {
+            if (!FileUtils.verifyImageSignature(headerBytes, extension)) {
                 log.error("File signature mismatch for file: {}. Expected: {}",
                         originalFilename, extension);
                 throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
             }
 
             // MIME 타입 검출 (스트림 기반)
-            String detectedMimeType = detectMimeTypeFromStream(inputStream, originalFilename);
+            String detectedMimeType = FileUtils.detectMimeTypeFromStream(inputStream, originalFilename);
 
             // 검출된 MIME 타입 검증
             if (!allowedImageTypes.contains(detectedMimeType)) {
@@ -409,7 +311,7 @@ public class FileService {
             }
 
             // Content-Type과 실제 검출된 타입 비교
-            validateContentType(file.getContentType(), detectedMimeType, originalFilename);
+            FileUtils.validateContentType(file.getContentType(), detectedMimeType, originalFilename);
 
             log.info("File validation successful. File: {}, Type: {}, Size: {} bytes",
                     originalFilename, detectedMimeType, file.getSize());
@@ -433,7 +335,8 @@ public class FileService {
             // 파일 처리 후 예상 메모리 사용률 계산
             double projectedUsageRatio = (double) (usedMemory + fileSize) / maxMemory;
 
-            log.debug("Memory usage - Current: {:.2f}%, Projected: {:.2f}%, Max allowed: {:.2f}%",
+            //얘는 차마 영어로 못 적겠다
+            log.debug("현재 메모리 사용률: {:.2f}%, 예상 메모리 사용률: {:.2f}%, 최대 허용률: {:.2f}%",
                     currentUsageRatio * 100, projectedUsageRatio * 100, MAX_MEMORY_USAGE_RATIO * 100);
 
             return projectedUsageRatio <= MAX_MEMORY_USAGE_RATIO;
@@ -444,90 +347,4 @@ public class FileService {
         }
     }
 
-    // 스트림에서 헤더만 읽기
-    private byte[] readHeader(InputStream inputStream, int maxHeaderSize) throws IOException {
-
-        if (!inputStream.markSupported()) {
-            throw new IOException("Stream does not support mark/reset");
-        }
-
-        inputStream.mark(maxHeaderSize); // 스트림 위치 마킹
-
-        byte[] headerBytes = new byte[maxHeaderSize];
-        int bytesRead = inputStream.read(headerBytes);
-
-        inputStream.reset(); // 스트림 위치 리셋
-
-        if (bytesRead <= 0) {
-            throw new IOException("Failed to read file header");
-        }
-
-        // 실제 읽은 크기만큼만 반환
-        byte[] actualHeader = new byte[bytesRead];
-        System.arraycopy(headerBytes, 0, actualHeader, 0, bytesRead);
-
-        return actualHeader;
-    }
-
-    // 스트림 기반 MIME 타입 검출
-    private String detectMimeTypeFromStream(InputStream inputStream, String filename) throws IOException {
-
-        inputStream.mark(BUFFER_SIZE); // 스트림 위치 마킹
-
-        try {
-            return tika.detect(inputStream, filename);
-        } finally {
-            inputStream.reset(); // 스트림 위치 리셋
-        }
-    }
-
-    // 확장자 추출 및 검증
-    private String extractAndValidateExtension(String originalFileName) {
-
-        // 파일명에서 모든 점(.) 위치 검사
-        String[] parts = originalFileName.split("\\.");
-        if (parts.length > 2) {
-            log.warn("Double extension detected: {}", originalFileName);
-            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
-        }
-
-        // 실제 확장자 추출
-        String extension = "";
-        int lastDotIndex = originalFileName.lastIndexOf(".");
-        if (lastDotIndex > 0 && lastDotIndex < originalFileName.length() - 1) {
-            extension = originalFileName.substring(lastDotIndex + 1).toLowerCase();
-        }
-
-        // 확장자가 없거나 빈 경우 거부
-        if (extension.isEmpty()) {
-            log.warn("No extension found in file: {}", originalFileName);
-            throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
-        }
-
-        // 위험한 확장자 블랙리스트 검증
-        for (String dangerous : DANGEROUS_EXTENSIONS) {
-            if (originalFileName.toLowerCase().contains("." + dangerous)) {
-                log.error("Dangerous extension detected: {}", originalFileName);
-                throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
-            }
-        }
-
-        // 허용된 확장자 화이트리스트 검증
-        if (!ALLOWED_EXTENSIONS.contains(extension)) {
-            log.warn("Not allowed extension: {}", extension);
-            throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
-        }
-
-        return extension;
-    }
-
-    // Content-Type 검증
-    private void validateContentType(String declaredContentType, String detectedMimeType, String filename) {
-
-        if (declaredContentType != null && !declaredContentType.equals(detectedMimeType)) {
-            log.warn("Content-Type mismatch. Declared: {}, Detected: {} for file: {}",
-                    declaredContentType, detectedMimeType, filename);
-            // 실제 타입이 허용된 이미지면 계속 진행
-        }
-    }
 }

--- a/src/main/java/com/mjsec/lms/service/FileService.java
+++ b/src/main/java/com/mjsec/lms/service/FileService.java
@@ -9,8 +9,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -20,6 +24,12 @@ import java.util.*;
 @Service
 @Slf4j
 public class FileService {
+
+    private static final int BUFFER_SIZE = 8192; // 8KB 청크 단위 처리
+    private static final int MAX_HEADER_SIZE = 1024; // 헤더 검증용 최대 크기
+    private static final double MAX_MEMORY_USAGE_RATIO = 0.8; // 최대 메모리 사용률 80%
+
+    private final MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
 
     // 파일 업로드 경로 설정값을 가져옴
     @Value("${file.upload.path:uploads/}")
@@ -80,33 +90,9 @@ public class FileService {
     // ========== 다중 이미지 처리 메서드들 ==========
 
     // 다중 이미지 업로드 메서드
-    public List<String> uploadMultipleImages(List<MultipartFile> files)  {
-        if (files == null || files.isEmpty()) {
-            log.debug("No files provided for upload");
-            return new ArrayList<>();
-        }
+    public List<String> uploadMultipleImages(List<MultipartFile> files) {
 
-        // 이미지 개수 제한 검증
-        if (files.size() > MAX_IMAGE_COUNT) {
-            log.warn("Too many images provided: {} (max: {})", files.size(), MAX_IMAGE_COUNT);
-            throw new RestApiException(ErrorCode.TOO_MANY_IMAGES);
-        }
-
-        List<String> uploadedUrls = new ArrayList<>();
-
-        for (MultipartFile file : files) {
-            // 빈 파일 스킵
-            if (file.isEmpty()) {
-                log.debug("Skipping empty file");
-                continue;
-            }
-
-            String uploadedUrl = uploadImage(file);
-            uploadedUrls.add(uploadedUrl);
-        }
-
-        log.info("Successfully uploaded {} images", uploadedUrls.size());
-        return uploadedUrls;
+        return uploadMultipleImagesMemorySafe(files);
     }
 
     // 다중 이미지 업데이트
@@ -152,6 +138,7 @@ public class FileService {
 
     // 다중 이미지 삭제 메서드
     public void deleteMultipleImages(List<String> imageUrls) {
+
         if (imageUrls == null || imageUrls.isEmpty()) {
             log.debug("No images to delete");
             return;
@@ -170,10 +157,60 @@ public class FileService {
         log.info("Deleted {}/{} images successfully", deletedCount, imageUrls.size());
     }
 
+    // 다중 파일 업로드 시 메모리 사용량 관리
+    public List<String> uploadMultipleImagesMemorySafe(List<MultipartFile> files) {
+
+        if (files == null || files.isEmpty()) {
+            log.debug("No files provided for upload");
+            return new ArrayList<>();
+        }
+
+        // 이미지 개수 제한 검증
+        if (files.size() > MAX_IMAGE_COUNT) {
+            log.warn("Too many images provided: {} (max: {})", files.size(), MAX_IMAGE_COUNT);
+            throw new RestApiException(ErrorCode.TOO_MANY_IMAGES);
+        }
+
+        // 전체 파일 크기 계산
+        long totalFileSize = files.stream().mapToLong(MultipartFile::getSize).sum();
+
+        // 전체 파일에 대한 메모리 체크
+        if (!checkMemoryAvailability(totalFileSize)) {
+            log.error("Insufficient memory for multiple file upload. Total size: {} bytes", totalFileSize);
+            throw new RestApiException(ErrorCode.INSUFFICIENT_MEMORY);
+        }
+
+        List<String> uploadedUrls = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            // 빈 파일 스킵
+            if (file.isEmpty()) {
+                log.debug("Skipping empty file");
+                continue;
+            }
+
+            String uploadedUrl = uploadImage(file);
+            uploadedUrls.add(uploadedUrl);
+
+            // 각 파일 업로드 후 메모리 상태 체크
+            if (log.isDebugEnabled()) {
+                long usedMemory = memoryBean.getHeapMemoryUsage().getUsed();
+                long maxMemory = memoryBean.getHeapMemoryUsage().getMax();
+                double usageRatio = (double) usedMemory / maxMemory;
+                log.debug("Memory usage after file upload: {:.2f}%", usageRatio * 100);
+            }
+        }
+
+        log.info("Successfully uploaded {} images with total size: {} bytes",
+                uploadedUrls.size(), totalFileSize);
+        return uploadedUrls;
+    }
+
     // 이미지 파일을 업로드하고 웹에서 접근 가능한 URL을 반환하는 메서드
     public String uploadImage(MultipartFile file) {
+
         // 파일 유효성 검사 수행
-        validateImageFile(file);
+        validateImageFileMemorySafe(file);
 
         // 고유한 파일명 생성
         String fileName = generateUniqueFileName(file.getOriginalFilename());
@@ -181,11 +218,13 @@ public class FileService {
 
         try {
             Path targetLocation = Paths.get(filePath);
-            // 파일을 지정된 경로에 저장 (기존 파일이 있으면 덮어쓰기)
-            Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+
+            // 스트림 기반 파일 복사 (메모리 효율적)
+            try (InputStream inputStream = file.getInputStream()) {
+                Files.copy(inputStream, targetLocation, StandardCopyOption.REPLACE_EXISTING);
+            }
 
             log.info("File uploaded successfully: {}", fileName);
-            // 웹에서 접근 가능한 URL 형태로 반환
             return "/uploads/" + fileName;
 
         } catch (IOException e) {
@@ -229,12 +268,32 @@ public class FileService {
         return currentImageUrl;
     }
 
+    // 기존에 업로드된 이미지 파일을 삭제하는 메서드
+    public void deleteImage(String imageUrl) {
+
+        // URL이 유효하고 uploads 경로로 시작하는지 확인
+        if (imageUrl != null && imageUrl.startsWith("/uploads/")) {
+            // URL에서 파일명 추출
+            String fileName = imageUrl.substring("/uploads/".length());
+            String filePath = uploadPath + fileName;
+
+            try {
+                // 파일이 존재하면 삭제
+                Files.deleteIfExists(Paths.get(filePath));
+                log.info("File deleted successfully: {}", fileName);
+            } catch (IOException e) {
+                log.error("Failed to delete file: {}", fileName, e);
+            }
+        }
+    }
+
     /*
     ------- PRIVATE ----------
      */
 
     // 파일 시그니처 검증 메서드
     private boolean verifyImageSignature(byte[] fileBytes, String expectedExtension) {
+
         if (fileBytes == null || fileBytes.length < 12) {
             return false;
         }
@@ -280,8 +339,28 @@ public class FileService {
         }
     }
 
-    // 업로드할 이미지 파일의 유효성을 검사하는 메서드
-    private void validateImageFile(MultipartFile file) {
+    // 원본 파일명을 기반으로 고유한 파일명을 생성하는 메서드
+    private String generateUniqueFileName(String originalFileName) {
+
+        if (originalFileName == null || originalFileName.trim().isEmpty()) {
+            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
+        }
+
+        String extension = extractAndValidateExtension(originalFileName);
+
+        String safeFileName = UUID.randomUUID().toString() + "." + extension;
+
+        if (safeFileName.contains("..") || safeFileName.contains("/") || safeFileName.contains("\\")) {
+            log.error("Path traversal attempt in generated filename: {}", safeFileName);
+            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
+        }
+
+        log.info("Safe filename generated: {} -> {}", originalFileName, safeFileName);
+        return safeFileName;
+    }
+
+    private void validateImageFileMemorySafe(MultipartFile file) {
+
         // 기본 검증
         if (file.isEmpty()) {
             throw new RestApiException(ErrorCode.EMPTY_FILE);
@@ -291,83 +370,128 @@ public class FileService {
             throw new RestApiException(ErrorCode.FILE_SIZE_EXCEEDED);
         }
 
+        // 메모리 사용량 체크
+        if (!checkMemoryAvailability(file.getSize())) {
+            log.error("Insufficient memory for file upload. File size: {} bytes", file.getSize());
+            throw new RestApiException(ErrorCode.INSUFFICIENT_MEMORY);
+        }
+
         // 원본 파일명 검증
         String originalFilename = file.getOriginalFilename();
         if (originalFilename == null) {
             throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
         }
 
-        // 확장자 추출
-        String extension = "";
-        int lastDotIndex = originalFilename.lastIndexOf(".");
-        if (lastDotIndex > 0 && lastDotIndex < originalFilename.length() - 1) {
-            extension = originalFilename.substring(lastDotIndex + 1).toLowerCase();
-        }
+        // 확장자 추출 및 검증
+        String extension = extractAndValidateExtension(originalFilename);
 
-        if (!ALLOWED_EXTENSIONS.contains(extension)) {
-            throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
-        }
+        // 스트림 기반 파일 검증
+        try (InputStream inputStream = new BufferedInputStream(file.getInputStream())) {
 
-        // 파일 바이트 읽기
-        byte[] fileBytes;
-        try {
-            fileBytes = file.getBytes();
+            // 헤더만 읽어서 Magic Number 검증 (메모리 효율적)
+            byte[] headerBytes = readHeader(inputStream, MAX_HEADER_SIZE);
+
+            // Magic Number 검증
+            if (!verifyImageSignature(headerBytes, extension)) {
+                log.error("File signature mismatch for file: {}. Expected: {}",
+                        originalFilename, extension);
+                throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
+            }
+
+            // MIME 타입 검출 (스트림 기반)
+            String detectedMimeType = detectMimeTypeFromStream(inputStream, originalFilename);
+
+            // 검출된 MIME 타입 검증
+            if (!allowedImageTypes.contains(detectedMimeType)) {
+                log.error("Detected MIME type {} is not allowed. File: {}",
+                        detectedMimeType, originalFilename);
+                throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
+            }
+
+            // Content-Type과 실제 검출된 타입 비교
+            validateContentType(file.getContentType(), detectedMimeType, originalFilename);
+
+            log.info("File validation successful. File: {}, Type: {}, Size: {} bytes",
+                    originalFilename, detectedMimeType, file.getSize());
+
         } catch (IOException e) {
-            log.error("Failed to read file bytes: {}", originalFilename, e);
+            log.error("Failed to read file stream: {}", originalFilename, e);
             throw new RestApiException(ErrorCode.FILE_UPLOAD_FAILED);
         }
-
-        // Magic Number 검증
-        if (!verifyImageSignature(fileBytes, extension)) {
-            log.error("File signature mismatch for file: {}. Expected: {}",
-                    originalFilename, extension);
-            throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
-        }
-
-        // Apache Tika를 사용한 실제 MIME 타입 검출
-        String detectedMimeType;
-        try {
-            detectedMimeType = tika.detect(new ByteArrayInputStream(fileBytes), originalFilename);
-        } catch (Exception e) {
-            log.error("Failed to detect MIME type with Tika", e);
-            throw new RestApiException(ErrorCode.FILE_UPLOAD_FAILED);
-        }
-
-        // 검출된 MIME 타입이 허용된 이미지 타입인지 확인
-        if (!allowedImageTypes.contains(detectedMimeType)) {
-            log.error("Detected MIME type {} is not allowed. File: {}",
-                    detectedMimeType, originalFilename);
-            throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
-        }
-
-        // Content-Type과 실제 검출된 타입 비교
-        String declaredContentType = file.getContentType();
-        if (declaredContentType != null && !declaredContentType.equals(detectedMimeType)) {
-            log.warn("Content-Type mismatch. Declared: {}, Detected: {} for file: {}",
-                    declaredContentType, detectedMimeType, originalFilename);
-            // 실제 타입이 허용된 이미지면 계속 진행
-        }
-
-        log.info("File validation successful. File: {}, Type: {}, Size: {} bytes",
-                originalFilename, detectedMimeType, file.getSize());
     }
 
+    // 메모리 가용성 체크
+    private boolean checkMemoryAvailability(long fileSize) {
 
-    // 원본 파일명을 기반으로 고유한 파일명을 생성하는 메서드
-    private String generateUniqueFileName(String originalFileName) {
+        try {
+            long usedMemory = memoryBean.getHeapMemoryUsage().getUsed();
+            long maxMemory = memoryBean.getHeapMemoryUsage().getMax();
 
-        if (originalFileName == null || originalFileName.trim().isEmpty()) {
-            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
+            // 현재 메모리 사용률 계산
+            double currentUsageRatio = (double) usedMemory / maxMemory;
+
+            // 파일 처리 후 예상 메모리 사용률 계산
+            double projectedUsageRatio = (double) (usedMemory + fileSize) / maxMemory;
+
+            log.debug("Memory usage - Current: {:.2f}%, Projected: {:.2f}%, Max allowed: {:.2f}%",
+                    currentUsageRatio * 100, projectedUsageRatio * 100, MAX_MEMORY_USAGE_RATIO * 100);
+
+            return projectedUsageRatio <= MAX_MEMORY_USAGE_RATIO;
+
+        } catch (Exception e) {
+            log.warn("Failed to check memory availability, allowing upload", e);
+            return true; // 메모리 체크 실패 시 업로드 허용 (안전장치)
+        }
+    }
+
+    // 스트림에서 헤더만 읽기
+    private byte[] readHeader(InputStream inputStream, int maxHeaderSize) throws IOException {
+
+        if (!inputStream.markSupported()) {
+            throw new IOException("Stream does not support mark/reset");
         }
 
-        //파일명에서 모든 점(.) 위치 검사 - 이중 확장자 탐지
+        inputStream.mark(maxHeaderSize); // 스트림 위치 마킹
+
+        byte[] headerBytes = new byte[maxHeaderSize];
+        int bytesRead = inputStream.read(headerBytes);
+
+        inputStream.reset(); // 스트림 위치 리셋
+
+        if (bytesRead <= 0) {
+            throw new IOException("Failed to read file header");
+        }
+
+        // 실제 읽은 크기만큼만 반환
+        byte[] actualHeader = new byte[bytesRead];
+        System.arraycopy(headerBytes, 0, actualHeader, 0, bytesRead);
+
+        return actualHeader;
+    }
+
+    // 스트림 기반 MIME 타입 검출
+    private String detectMimeTypeFromStream(InputStream inputStream, String filename) throws IOException {
+
+        inputStream.mark(BUFFER_SIZE); // 스트림 위치 마킹
+
+        try {
+            return tika.detect(inputStream, filename);
+        } finally {
+            inputStream.reset(); // 스트림 위치 리셋
+        }
+    }
+
+    // 확장자 추출 및 검증
+    private String extractAndValidateExtension(String originalFileName) {
+
+        // 파일명에서 모든 점(.) 위치 검사
         String[] parts = originalFileName.split("\\.");
         if (parts.length > 2) {
             log.warn("Double extension detected: {}", originalFileName);
             throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
         }
 
-        // 실제 확장자 추출 (마지막 점 이후)
+        // 실제 확장자 추출
         String extension = "";
         int lastDotIndex = originalFileName.lastIndexOf(".");
         if (lastDotIndex > 0 && lastDotIndex < originalFileName.length() - 1) {
@@ -394,32 +518,16 @@ public class FileService {
             throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
         }
 
-        String safeFileName = UUID.randomUUID().toString() + "." + extension;
-
-        if (safeFileName.contains("..") || safeFileName.contains("/") || safeFileName.contains("\\")) {
-            log.error("Path traversal attempt in generated filename: {}", safeFileName);
-            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
-        }
-
-        log.info("Safe filename generated: {} -> {}", originalFileName, safeFileName);
-        return safeFileName;
+        return extension;
     }
 
-    // 기존에 업로드된 이미지 파일을 삭제하는 메서드
-    public void deleteImage(String imageUrl) {
-        // URL이 유효하고 uploads 경로로 시작하는지 확인
-        if (imageUrl != null && imageUrl.startsWith("/uploads/")) {
-            // URL에서 파일명 추출
-            String fileName = imageUrl.substring("/uploads/".length());
-            String filePath = uploadPath + fileName;
+    // Content-Type 검증
+    private void validateContentType(String declaredContentType, String detectedMimeType, String filename) {
 
-            try {
-                // 파일이 존재하면 삭제
-                Files.deleteIfExists(Paths.get(filePath));
-                log.info("File deleted successfully: {}", fileName);
-            } catch (IOException e) {
-                log.error("Failed to delete file: {}", fileName, e);
-            }
+        if (declaredContentType != null && !declaredContentType.equals(detectedMimeType)) {
+            log.warn("Content-Type mismatch. Declared: {}, Detected: {} for file: {}",
+                    declaredContentType, detectedMimeType, filename);
+            // 실제 타입이 허용된 이미지면 계속 진행
         }
     }
 }

--- a/src/main/java/com/mjsec/lms/service/FileService.java
+++ b/src/main/java/com/mjsec/lms/service/FileService.java
@@ -4,27 +4,45 @@ import com.mjsec.lms.exception.RestApiException;
 import com.mjsec.lms.type.ErrorCode;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tika.Tika;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @Slf4j
 public class FileService {
 
-    // application.yml에서 파일 업로드 경로 설정값을 가져옴 (기본값: uploads/)
+    // 파일 업로드 경로 설정값을 가져옴
     @Value("${file.upload.path:uploads/}")
     private String uploadPath;
+
+    // Apache Tika 인스턴스
+    private final Tika tika = new Tika();
+
+    // 이미지 파일 시그니처 (Magic Numbers)
+    private static final Map<String, byte[]> IMAGE_SIGNATURES = new HashMap<>();
+
+    static {
+        // JPEG
+        IMAGE_SIGNATURES.put("jpg", new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF});
+        // PNG
+        IMAGE_SIGNATURES.put("png", new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A});
+        // GIF
+        IMAGE_SIGNATURES.put("gif87", "GIF87a".getBytes());
+        IMAGE_SIGNATURES.put("gif89", "GIF89a".getBytes());
+        // WebP
+        IMAGE_SIGNATURES.put("webp_riff", "RIFF".getBytes());
+        IMAGE_SIGNATURES.put("webp_sig", "WEBP".getBytes());
+    }
 
     // 최대 파일 크기 설정 (기본값: 10MB)
     @Value("${file.upload.max-size:10485760}") // 10MB
@@ -35,6 +53,17 @@ public class FileService {
     // 허용되는 이미지 파일 타입 목록
     private final List<String> allowedImageTypes = Arrays.asList(
             "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"
+    );
+
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList(
+            "jpg", "jpeg", "png", "gif", "webp"
+    );
+
+    private static final List<String> DANGEROUS_EXTENSIONS = Arrays.asList(
+            "jsp", "jspx", "php", "php3", "php4", "php5", "phtml",
+            "asp", "aspx", "ascx", "ashx", "asmx",
+            "exe", "dll", "com", "bat", "cmd", "sh", "bash",
+            "cgi", "pl", "py", "rb", "js", "jar", "war"
     );
 
     // 스프링 빈 생성 후 실행되는 초기화 메서드
@@ -51,7 +80,7 @@ public class FileService {
     // ========== 다중 이미지 처리 메서드들 ==========
 
     // 다중 이미지 업로드 메서드
-    public List<String> uploadMultipleImages(List<MultipartFile> files) {
+    public List<String> uploadMultipleImages(List<MultipartFile> files)  {
         if (files == null || files.isEmpty()) {
             log.debug("No files provided for upload");
             return new ArrayList<>();
@@ -200,34 +229,180 @@ public class FileService {
         return currentImageUrl;
     }
 
+    /*
+    ------- PRIVATE ----------
+     */
+
+    // 파일 시그니처 검증 메서드
+    private boolean verifyImageSignature(byte[] fileBytes, String expectedExtension) {
+        if (fileBytes == null || fileBytes.length < 12) {
+            return false;
+        }
+
+        expectedExtension = expectedExtension.toLowerCase();
+
+        try {
+            // JPEG 검증
+            if (expectedExtension.equals("jpg") || expectedExtension.equals("jpeg")) {
+                return fileBytes[0] == (byte) 0xFF &&
+                        fileBytes[1] == (byte) 0xD8 &&
+                        fileBytes[2] == (byte) 0xFF;
+            }
+
+            // PNG 검증
+            if (expectedExtension.equals("png")) {
+                byte[] pngSignature = IMAGE_SIGNATURES.get("png");
+                for (int i = 0; i < pngSignature.length; i++) {
+                    if (fileBytes[i] != pngSignature[i]) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            // GIF 검증
+            if (expectedExtension.equals("gif")) {
+                String header = new String(fileBytes, 0, 6);
+                return header.equals("GIF87a") || header.equals("GIF89a");
+            }
+
+            // WebP 검증
+            if (expectedExtension.equals("webp")) {
+                String riff = new String(fileBytes, 0, 4);
+                String webp = new String(fileBytes, 8, 4);
+                return riff.equals("RIFF") && webp.equals("WEBP");
+            }
+
+            return false;
+        } catch (Exception e) {
+            log.error("Error verifying image signature", e);
+            return false;
+        }
+    }
+
     // 업로드할 이미지 파일의 유효성을 검사하는 메서드
     private void validateImageFile(MultipartFile file) {
-        // 빈 파일인지 확인
+        // 기본 검증
         if (file.isEmpty()) {
             throw new RestApiException(ErrorCode.EMPTY_FILE);
         }
 
-        // 파일 크기가 허용 범위를 초과하는지 확인
         if (file.getSize() > maxFileSize) {
             throw new RestApiException(ErrorCode.FILE_SIZE_EXCEEDED);
         }
 
-        // 파일 타입이 허용되는 이미지 타입인지 확인
-        String contentType = file.getContentType();
-        if (!allowedImageTypes.contains(contentType)) {
+        // 원본 파일명 검증
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null) {
+            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
+        }
+
+        // 확장자 추출
+        String extension = "";
+        int lastDotIndex = originalFilename.lastIndexOf(".");
+        if (lastDotIndex > 0 && lastDotIndex < originalFilename.length() - 1) {
+            extension = originalFilename.substring(lastDotIndex + 1).toLowerCase();
+        }
+
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
             throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
         }
+
+        // 파일 바이트 읽기
+        byte[] fileBytes;
+        try {
+            fileBytes = file.getBytes();
+        } catch (IOException e) {
+            log.error("Failed to read file bytes: {}", originalFilename, e);
+            throw new RestApiException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        // Magic Number 검증
+        if (!verifyImageSignature(fileBytes, extension)) {
+            log.error("File signature mismatch for file: {}. Expected: {}",
+                    originalFilename, extension);
+            throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        // Apache Tika를 사용한 실제 MIME 타입 검출
+        String detectedMimeType;
+        try {
+            detectedMimeType = tika.detect(new ByteArrayInputStream(fileBytes), originalFilename);
+        } catch (Exception e) {
+            log.error("Failed to detect MIME type with Tika", e);
+            throw new RestApiException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        // 검출된 MIME 타입이 허용된 이미지 타입인지 확인
+        if (!allowedImageTypes.contains(detectedMimeType)) {
+            log.error("Detected MIME type {} is not allowed. File: {}",
+                    detectedMimeType, originalFilename);
+            throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        // Content-Type과 실제 검출된 타입 비교
+        String declaredContentType = file.getContentType();
+        if (declaredContentType != null && !declaredContentType.equals(detectedMimeType)) {
+            log.warn("Content-Type mismatch. Declared: {}, Detected: {} for file: {}",
+                    declaredContentType, detectedMimeType, originalFilename);
+            // 실제 타입이 허용된 이미지면 계속 진행
+        }
+
+        log.info("File validation successful. File: {}, Type: {}, Size: {} bytes",
+                originalFilename, detectedMimeType, file.getSize());
     }
+
 
     // 원본 파일명을 기반으로 고유한 파일명을 생성하는 메서드
     private String generateUniqueFileName(String originalFileName) {
-        String extension = "";
-        // 원본 파일명에서 확장자 추출
-        if (originalFileName != null && originalFileName.contains(".")) {
-            extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+
+        if (originalFileName == null || originalFileName.trim().isEmpty()) {
+            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
         }
-        // UUID를 사용하여 고유한 파일명 생성
-        return UUID.randomUUID().toString() + extension;
+
+        //파일명에서 모든 점(.) 위치 검사 - 이중 확장자 탐지
+        String[] parts = originalFileName.split("\\.");
+        if (parts.length > 2) {
+            log.warn("Double extension detected: {}", originalFileName);
+            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
+        }
+
+        // 실제 확장자 추출 (마지막 점 이후)
+        String extension = "";
+        int lastDotIndex = originalFileName.lastIndexOf(".");
+        if (lastDotIndex > 0 && lastDotIndex < originalFileName.length() - 1) {
+            extension = originalFileName.substring(lastDotIndex + 1).toLowerCase();
+        }
+
+        // 확장자가 없거나 빈 경우 거부
+        if (extension.isEmpty()) {
+            log.warn("No extension found in file: {}", originalFileName);
+            throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        // 위험한 확장자 블랙리스트 검증
+        for (String dangerous : DANGEROUS_EXTENSIONS) {
+            if (originalFileName.toLowerCase().contains("." + dangerous)) {
+                log.error("Dangerous extension detected: {}", originalFileName);
+                throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
+            }
+        }
+
+        // 허용된 확장자 화이트리스트 검증
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            log.warn("Not allowed extension: {}", extension);
+            throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        String safeFileName = UUID.randomUUID().toString() + "." + extension;
+
+        if (safeFileName.contains("..") || safeFileName.contains("/") || safeFileName.contains("\\")) {
+            log.error("Path traversal attempt in generated filename: {}", safeFileName);
+            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
+        }
+
+        log.info("Safe filename generated: {} -> {}", originalFileName, safeFileName);
+        return safeFileName;
     }
 
     // 기존에 업로드된 이미지 파일을 삭제하는 메서드

--- a/src/main/java/com/mjsec/lms/type/ErrorCode.java
+++ b/src/main/java/com/mjsec/lms/type/ErrorCode.java
@@ -120,6 +120,7 @@ public enum ErrorCode {
     IMAGE_NOT_READABLE(HttpStatus.INTERNAL_SERVER_ERROR,  "이미지 파일을 읽을 수 없습니다."),
     IMAGE_LOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 로딩 중 오류가 발생했습니다."),
     TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "이미지는 최대 5개까지만 업로드할 수 있습니다."),
+    INSUFFICIENT_MEMORY(HttpStatus.SERVICE_UNAVAILABLE, "서버 메모리가 부족하여 파일을 처리할 수 없습니다. 잠시 후 다시 시도해주세요."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/mjsec/lms/util/FileUtils.java
+++ b/src/main/java/com/mjsec/lms/util/FileUtils.java
@@ -1,0 +1,205 @@
+package com.mjsec.lms.util;
+
+import com.mjsec.lms.exception.RestApiException;
+import com.mjsec.lms.type.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tika.Tika;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+@Component
+@Slf4j
+public class FileUtils {
+
+    private static final int BUFFER_SIZE = 8192; // 8KB 청크 단위 처리
+
+    // Apache Tika 인스턴스
+    private static final Tika tika = new Tika();
+
+    // 이미지 파일 시그니처 (Magic Numbers)
+    private static final Map<String, byte[]> IMAGE_SIGNATURES = new HashMap<>();
+
+    static {
+        // JPEG
+        IMAGE_SIGNATURES.put("jpg", new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF});
+        // PNG
+        IMAGE_SIGNATURES.put("png", new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A});
+        // GIF
+        IMAGE_SIGNATURES.put("gif87", "GIF87a".getBytes());
+        IMAGE_SIGNATURES.put("gif89", "GIF89a".getBytes());
+        // WebP
+        IMAGE_SIGNATURES.put("webp_riff", "RIFF".getBytes());
+        IMAGE_SIGNATURES.put("webp_sig", "WEBP".getBytes());
+    }
+
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList(
+            "jpg", "jpeg", "png", "gif", "webp"
+    );
+
+    private static final List<String> DANGEROUS_EXTENSIONS = Arrays.asList(
+            "jsp", "jspx", "php", "php3", "php4", "php5", "phtml",
+            "asp", "aspx", "ascx", "ashx", "asmx",
+            "exe", "dll", "com", "bat", "cmd", "sh", "bash",
+            "cgi", "pl", "py", "rb", "js", "jar", "war"
+    );
+
+    // 원본 파일명을 기반으로 고유한 파일명을 생성하는 메서드
+    public static String generateUniqueFileName(String originalFileName) {
+
+        if (originalFileName == null || originalFileName.trim().isEmpty()) {
+            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
+        }
+
+        String extension = extractAndValidateExtension(originalFileName);
+
+        String safeFileName = UUID.randomUUID().toString() + "." + extension;
+
+        if (safeFileName.contains("..") || safeFileName.contains("/") || safeFileName.contains("\\")) {
+            log.error("Path traversal attempt in generated filename: {}", safeFileName);
+            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
+        }
+
+        log.info("Safe filename generated: {} -> {}", originalFileName, safeFileName);
+        return safeFileName;
+    }
+
+    // 파일 시그니처 검증 메서드
+    public static boolean verifyImageSignature(byte[] fileBytes, String expectedExtension) {
+
+        if (fileBytes == null || fileBytes.length < 12) {
+            return false;
+        }
+
+        expectedExtension = expectedExtension.toLowerCase();
+
+        try {
+            // JPEG 검증
+            if (expectedExtension.equals("jpg") || expectedExtension.equals("jpeg")) {
+                return fileBytes[0] == (byte) 0xFF &&
+                        fileBytes[1] == (byte) 0xD8 &&
+                        fileBytes[2] == (byte) 0xFF;
+            }
+
+            // PNG 검증
+            if (expectedExtension.equals("png")) {
+                byte[] pngSignature = IMAGE_SIGNATURES.get("png");
+                for (int i = 0; i < pngSignature.length; i++) {
+                    if (fileBytes[i] != pngSignature[i]) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            // GIF 검증
+            if (expectedExtension.equals("gif")) {
+                String header = new String(fileBytes, 0, 6);
+                return header.equals("GIF87a") || header.equals("GIF89a");
+            }
+
+            // WebP 검증
+            if (expectedExtension.equals("webp")) {
+                String riff = new String(fileBytes, 0, 4);
+                String webp = new String(fileBytes, 8, 4);
+                return riff.equals("RIFF") && webp.equals("WEBP");
+            }
+
+            return false;
+        } catch (Exception e) {
+            log.error("Error verifying image signature", e);
+            return false;
+        }
+    }
+
+    // 확장자 추출 및 검증
+    public static String extractAndValidateExtension(String originalFileName) {
+
+        // 파일명에서 모든 점(.) 위치 검사
+        String[] parts = originalFileName.split("\\.");
+        if (parts.length > 2) {
+            log.warn("Double extension detected: {}", originalFileName);
+            throw new RestApiException(ErrorCode.INVALID_FILE_NAME);
+        }
+
+        // 실제 확장자 추출
+        String extension = "";
+        int lastDotIndex = originalFileName.lastIndexOf(".");
+        if (lastDotIndex > 0 && lastDotIndex < originalFileName.length() - 1) {
+            extension = originalFileName.substring(lastDotIndex + 1).toLowerCase();
+        }
+
+        // 확장자가 없거나 빈 경우 거부
+        if (extension.isEmpty()) {
+            log.warn("No extension found in file: {}", originalFileName);
+            throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        // 위험한 확장자 블랙리스트 검증
+        for (String dangerous : DANGEROUS_EXTENSIONS) {
+            if (originalFileName.toLowerCase().contains("." + dangerous)) {
+                log.error("Dangerous extension detected: {}", originalFileName);
+                throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
+            }
+        }
+
+        // 허용된 확장자 화이트리스트 검증
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            log.warn("Not allowed extension: {}", extension);
+            throw new RestApiException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        return extension;
+    }
+
+    // Content-Type 검증
+    public static void validateContentType(String declaredContentType, String detectedMimeType, String filename) {
+
+        if (declaredContentType != null && !declaredContentType.equals(detectedMimeType)) {
+            log.warn("Content-Type mismatch. Declared: {}, Detected: {} for file: {}",
+                    declaredContentType, detectedMimeType, filename);
+            // 실제 타입이 허용된 이미지면 계속 진행
+        }
+    }
+
+    // 스트림에서 헤더만 읽기
+    public static byte[] readHeader(InputStream inputStream, int maxHeaderSize) throws IOException {
+
+        if (!inputStream.markSupported()) {
+            throw new IOException("Stream does not support mark/reset");
+        }
+
+        inputStream.mark(maxHeaderSize); // 스트림 위치 마킹
+
+        byte[] headerBytes = new byte[maxHeaderSize];
+        int bytesRead = inputStream.read(headerBytes);
+
+        inputStream.reset(); // 스트림 위치 리셋
+
+        if (bytesRead <= 0) {
+            throw new IOException("Failed to read file header");
+        }
+
+        // 실제 읽은 크기만큼만 반환
+        byte[] actualHeader = new byte[bytesRead];
+        System.arraycopy(headerBytes, 0, actualHeader, 0, bytesRead);
+
+        return actualHeader;
+    }
+
+    // 스트림 기반 MIME 타입 검출
+    public static String detectMimeTypeFromStream(InputStream inputStream, String filename) throws IOException {
+
+        inputStream.mark(BUFFER_SIZE); // 스트림 위치 마킹
+
+        try {
+            return tika.detect(inputStream, filename);
+        } finally {
+            inputStream.reset(); // 스트림 위치 리셋
+        }
+    }
+
+
+}

--- a/src/main/java/com/mjsec/lms/util/IpUtils.java
+++ b/src/main/java/com/mjsec/lms/util/IpUtils.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 //IP 주소 추출을 위한 유틸리티 클래스
+@Component
 public class IpUtils {
 
     private static final String[] IP_HEADERS = {

--- a/src/main/java/com/mjsec/lms/util/IpUtils.java
+++ b/src/main/java/com/mjsec/lms/util/IpUtils.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 //IP 주소 추출을 위한 유틸리티 클래스
-@Component
 public class IpUtils {
 
     private static final String[] IP_HEADERS = {
@@ -71,7 +70,7 @@ public class IpUtils {
                 "localhost".equalsIgnoreCase(ip);
     }
 
-    // 유틸리티 클래스이므로 인스턴스화 방지
+    // 유틸리티 클래스이므로 인스턴스화 방지 <- @Component 금지
     private IpUtils() {
         throw new IllegalStateException("Utility class");
     }

--- a/src/main/java/com/mjsec/lms/util/ValidationUtils.java
+++ b/src/main/java/com/mjsec/lms/util/ValidationUtils.java
@@ -328,8 +328,7 @@ public class ValidationUtils {
     }
 
     //과제 제출 상태 ENUM 타입 검증
-    public SubmissionStatus validateSubmissionStatus(SubmissionStatus status) {
-        String statusString = status.toString();
+    public SubmissionStatus validateSubmissionStatus(String statusString) {
 
         if (statusString == null || statusString.trim().isEmpty()) {
             throw new RestApiException(ErrorCode.INVALID_SUBMISSION_STATUS);


### PR DESCRIPTION
### 이미지 업로드 보안성 높이기 

**Apache Tika 의존성 추가**
* 파일의 실제 MIME 타입을 검출하기 위해 Apache Tika 라이브러리를 build.gradle에 추가

**Double Extension 공격 방어 코드 추가**
-> 기존 generateUniqueFileName 메서드에서 test.php.jpg 같은 이중 확장자를 허용하는 문제

파일명을 점(.)으로 분리하여 개수를 체크하는 검증 로직을 추가
위험한 확장자 블랙리스트(jsp, php, asp 등)를 만들어 파일명 어디에든 해당 확장자가 포함되면 차단
허용된 확장자 화이트리스트(jpg, jpeg, png, gif, webp)만 통과하도록 이중 검증을 추가
null byte injection 공격 방어를 위해 파일명에 \0이 포함되어 있는지 검사
파일명 길이를 255자로 제한하여 버퍼 오버플로우를 방지

**Magic Number(파일 시그니처) 검증 기능 추가**

Content-Type 헤더는 클라이언트가 조작 가능하므로 신뢰 불가능
verifyImageSignature 메서드를 새로 만들어 파일의 실제 바이트를 읽어 진짜 이미지 파일인지 확인
JPEG는 FF D8 FF로 시작하는지, PNG는 89 50 4E 47로 시작하는지 등 각 이미지 포맷의 고유 시그니처를 검증
IMAGE_SIGNATURES라는 static Map을 추가하여 각 이미지 타입별 시그니처를 정의

**Apache Tika를 통한 실제 MIME 타입 검출**

validateImageFile 메서드에 Tika를 사용한 MIME 타입 검출 로직을 추가
클라이언트가 보낸 Content-Type과 Tika가 검출한 실제 타입을 비교하여 불일치 시 경고 로그를 남김
실제 검출된 MIME 타입이 허용된 이미지 타입 목록에 있는지 최종 검증

**메모리 기반 DoS 공격 방어 추가**

* 전체 파일을 메모리에 로드하는 file.getBytes() 방식의 메모리 고갈 위험 해결
* 스트림 기반 파일 처리로 전환하여 8KB 청크 단위로 파일 처리
* MemoryMXBean을 활용한 실시간 메모리 사용률 모니터링 기능 추가
* 메모리 사용률 80% 임계점 설정으로 대용량 파일 업로드 시 서버 보호
* mark()/reset() 기능을 활용한 헤더만 읽기로 Magic Number 검증 시 메모리 효율성 극대화
* Apache Tika MIME 타입 검출도 스트림 기반으로 변경하여 메모리 사용량 최소화
* markSupported() 체크로 스트림 안전성 검증 추가
* 다중 파일 업로드 시 전체 파일 크기 사전 계산 후 메모리 체크 수행
* INSUFFICIENT_MEMORY 에러 코드 추가로 메모리 부족 상황 명확히 처리
---

참고로 위에 있는 대부분의 보안적 코드는 클로드가 작성해준다는 것을 알아주십쇼. (보안력 다 빠짐 이슈)
저는 먼저 코드를 작성 후 해당 보안 이슈에 대해 블로그, 공식 문서로 공부하고 있습니다.
그렇기에 먼저 PR을 작성해서 올려두고 계속 공부하면서 수정과 추가를 이어나갈 계획입니당
한번에 다 올리면 나도 기억 못해

**고민중인 거 : Rate Limiting 추가 <- 예전에 혼자 Spring 가지고 놀 때 한번 만들어본 경험은 있음.**
* 근데 이거까지 필요할까? 라는 생각이 들긴 함. 파일 올리는 거에서 과부화 일으키거나 DDos 방지용의 의미가 클듯?

댓글로 한번씩 피드백 주시기를 오네가이시마스
