### PR TITLE
feat(admin): add get group detail info feature for admin

### DIFF
--- a/src/main/java/com/mjsec/lms/controller/AdminController.java
+++ b/src/main/java/com/mjsec/lms/controller/AdminController.java
@@ -2,11 +2,13 @@ package com.mjsec.lms.controller;
 
 import com.mjsec.lms.dto.AllStudyGroupDto;
 import com.mjsec.lms.dto.PendingUserDto;
+import com.mjsec.lms.dto.StudyGroupDetailDto;
 import com.mjsec.lms.dto.StudyGroupDto.StudyGroupRequestDto;
 import com.mjsec.lms.dto.StudyGroupDto.StudyGroupUpdateDto;
 import com.mjsec.lms.dto.SuccessResponse;
 import com.mjsec.lms.dto.UserAdminResponseDto;
 import com.mjsec.lms.service.AdminService;
+import com.mjsec.lms.service.StudyGroupService;
 import com.mjsec.lms.type.ResponseMessage;
 import jakarta.validation.Valid;
 
@@ -15,6 +17,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,6 +35,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class AdminController {
 
     private final AdminService adminService;
+    private final StudyGroupService studyGroupService;
 
     @GetMapping("/member-approval")
     public ResponseEntity<SuccessResponse<List<PendingUserDto>>> getAllPendingUser(){
@@ -177,6 +181,20 @@ public class AdminController {
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessResponse.of(
                         ResponseMessage.UPDATE_GROUP_STATUS_SUCCESS
+                )
+        );
+    }
+
+    @GetMapping("/group/{groupId}/info")
+    public ResponseEntity<SuccessResponse<StudyGroupDetailDto>> getStudyGroupDetail(
+            @PathVariable Long groupId) {
+
+        StudyGroupDetailDto studyGroupDetail = studyGroupService.getStudyGroupDetailForAdmin(groupId);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ResponseMessage.STUDY_GROUP_DETAIL_GET_SUCCESS,
+                        studyGroupDetail
                 )
         );
     }

--- a/src/main/java/com/mjsec/lms/service/StudyGroupService.java
+++ b/src/main/java/com/mjsec/lms/service/StudyGroupService.java
@@ -266,6 +266,37 @@ public class StudyGroupService {
         return createStudyGroupDetailDto(studyGroup, mentor, menteeInfoList);
     }
 
+    // 관리자 권한으로 특정 그룹 상세 정보 조회
+    public StudyGroupDetailDto getStudyGroupDetailForAdmin(Long groupId) {
+
+        log.info("getStudyGroupDetailForAdmin called for group: {}", groupId);
+
+        StudyGroup studyGroup = validationUtils.validateStudyGroup(groupId);
+
+        // 그룹의 모든 멤버 조회
+        List<GroupMember> allMembers = groupMemberRepository.findByStudyGroup_StudyId(groupId);
+
+        // 멘토와 멘티 분리
+        GroupMember mentor = allMembers.stream()
+                .filter(member -> member.getRole() == GroupMemberRole.MENTOR)
+                .findFirst()
+                .orElse(null);
+
+        List<GroupMember> mentees = allMembers.stream()
+                .filter(member -> member.getRole() == GroupMemberRole.MENTEE)
+                .toList();
+
+        // 멘티 정보 DTO 리스트 생성
+        List<StudyGroupDetailDto.MenteeInfo> menteeInfoList = mentees.stream()
+                .map(this::createMenteeInfo)
+                .collect(Collectors.toList());
+
+        log.info("Found {} total members in study group: {} (1 mentor, {} mentees)",
+                allMembers.size(), groupId, mentees.size());
+
+        return createStudyGroupDetailDto(studyGroup, mentor, menteeInfoList);
+    }
+
     /*
     그 외 Private 메서드
      */


### PR DESCRIPTION
## 변경사항
- ADMIN 권한을 가진 사용자가 특정 스터디 그룹의 상세 정보를 조회할 수 있는 기능을 추가하였습니다.
<img width="693" height="106" alt="스크린샷 2026-01-27 오후 6 09 16" src="https://github.com/user-attachments/assets/74a6bf2e-37ff-468e-acb5-cd178e213b49" />

API는 다음과 같습니다
- (GET) /api/v1/admin/group/{groupId}/info
- 필수 헤더 : JWT Token
- 필수 파라미터 : groupId (스터디 그룹의 Id)

기존에 있던 StudyGroupService.getStudyGroupDetail 메서드 내의 validationUtils.validateBasicAccess(groupId, currentUserStudentNumber); 로직을 삭제한 새로운 메서드를 StudyGroupService에 작성하였습니다.

AdminController의 getStudyGroupDetail에서 StudyGroupService.getStudyGroupDetailForAdmin 메서드를 호출합니다.

## 테스트

1. 관리자 권한을 가진 사용자로 로그인 
<img width="1260" height="946" alt="스크린샷 2026-01-27 오후 6 02 07" src="https://github.com/user-attachments/assets/56e4344d-0a95-4eb7-a9fb-749173524112" />

2. (GET) /api/v1/admin/group/{groupId}/info에 Request
<img width="1260" height="946" alt="스크린샷 2026-01-27 오후 6 02 42" src="https://github.com/user-attachments/assets/7c793c10-591b-47e7-a2fd-f613a8ad1eff" />

-> 200 OK

## 예외처리 테스트

1. 일반 사용자로 로그인
<img width="1470" height="459" alt="스크린샷 2026-01-27 오후 6 06 49" src="https://github.com/user-attachments/assets/f0deaa77-ef34-4800-b601-b861d074f226" />
ROLE_USER 권한을 가진 60201344 '정유찬'의 계정으로 로그인

<img width="1260" height="946" alt="스크린샷 2026-01-27 오후 6 05 56" src="https://github.com/user-attachments/assets/140b0916-dc25-4a4c-b099-4f6fe71aea4a" />

2. (GET) /api/v1/admin/group/{groupId}/info에 Request
<img width="1260" height="946" alt="스크린샷 2026-01-27 오후 6 06 22" src="https://github.com/user-attachments/assets/75b2b200-7192-46fe-aee2-d49a0f761d1b" />

-> 403 Forbidden
