### PR TITLE
fix(admin-group-deatil-info): add transactional annotation

### DIFF
--- a/src/main/java/com/mjsec/lms/service/StudyGroupService.java
+++ b/src/main/java/com/mjsec/lms/service/StudyGroupService.java
@@ -267,6 +267,7 @@ public class StudyGroupService {
     }
 
     // 관리자 권한으로 특정 그룹 상세 정보 조회
+    @Transactional(readOnly = true)
     public StudyGroupDetailDto getStudyGroupDetailForAdmin(Long groupId) {
 
         log.info("getStudyGroupDetailForAdmin called for group: {}", groupId);


### PR DESCRIPTION
## 변경 사항
- 지연 로딩을 고려하지 않고 코드를 짜서 다음과 같은 문제가 발생하였습니다...
```
org.hibernate.LazyInitializationException
```
이 문제는 Repository 메소드(예: findById)가 실행될 때만 잠깐 데이터베이스 세션이 열렸다가, 메소드가 끝나자마자 바로 닫히기 때문에 발생합니다. 이미 DB 세션이 닫혔는데 Service 계층에서 메서드를 호출하려고 하면 이미 연결이 끊겨서 위와 같은 에러 메시지가 뜨게 되는 거죠...

따라서 @Transactional(readOnly = true)를 서비스 메서드 위에 붙여주었습니다. 위 어노테이션을 붙이게 되면 메소드 시작부터 끝까지 데이터베이스 연결(영속성 컨텍스트)을 계속 유지합니다. 

<img width="604" height="110" alt="스크린샷 2026-01-30 오후 7 50 13" src="https://github.com/user-attachments/assets/2eee12f7-379b-4dac-b672-55dc33b4e651" />
